### PR TITLE
docs: Add watchOS docs

### DIFF
--- a/CareKitEssentials.xcodeproj/project.pbxproj
+++ b/CareKitEssentials.xcodeproj/project.pbxproj
@@ -767,7 +767,7 @@
 			repositoryURL = "https://github.com/cbaker6/CareKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "3.0.0-beta.10";
+				minimumVersion = "3.0.0-beta.12";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CareKitEssentials.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CareKitEssentials.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cbaker6/CareKit.git",
       "state" : {
-        "revision" : "075d600052f168d49b542444577cf20033eb9666",
-        "version" : "3.0.0-beta.10"
+        "revision" : "671cfa7bc608f5ed985aebef5ebd2b135b7e5a3c",
+        "version" : "3.0.0-beta.12"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cbaker6/CareKit.git",
       "state" : {
-        "revision" : "075d600052f168d49b542444577cf20033eb9666",
-        "version" : "3.0.0-beta.10"
+        "revision" : "671cfa7bc608f5ed985aebef5ebd2b135b7e5a3c",
+        "version" : "3.0.0-beta.12"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/cbaker6/CareKit.git",
-                 .upToNextMajor(from: "3.0.0-beta.10"))
+                 .upToNextMajor(from: "3.0.0-beta.12"))
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CareKitEssentials
 
-[![Documentation](https://img.shields.io/badge/read_-docs-2196f3.svg)](https://swiftpackageindex.com/netreconlab/CareKitEssentials/documentation/)
+[![Documentation](https://img.shields.io/badge/read_-iOS_docs-2196f3.svg)](https://swiftpackageindex.com/netreconlab/CareKitEssentials/documentation/)
+[![Documentation](https://img.shields.io/badge/read_-watchOS_docs-2196f3.svg)](https://netreconlab.github.io/CareKitEssentials/release/documentation/carekitessentials/)
 [![Tuturiol](https://img.shields.io/badge/read_-tuturials-2196f3.svg)](https://netreconlab.github.io/CareKitEssentials/release/tutorials/carekitessentials/)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fnetreconlab%2FCareKitEssentials%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/netreconlab/CareKitEssentials)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fnetreconlab%2FCareKitEssentials%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/netreconlab/CareKitEssentials)

--- a/Scripts/generate-documentation
+++ b/Scripts/generate-documentation
@@ -103,7 +103,7 @@ mkdir "$TEMP_WORKSPACE_DIR"
 mv CareKitEssentials.xcodeproj "$TEMP_WORKSPACE_DIR/CareKitEssentials.xcodeproj"
 
 xcodebuild clean build -scheme CareKitEssentials \
-    -destination generic/platform=iOS \
+    -destination generic/platform=watchOS \
     OTHER_SWIFT_FLAGS="-emit-symbol-graph -emit-symbol-graph-dir '$SGFS_DIR'" | xcpretty
 
 mv "$TEMP_WORKSPACE_DIR/CareKitEssentials.xcodeproj" ./CareKitEssentials.xcodeproj


### PR DESCRIPTION
- [x] Build watchOS docs using GitHub pages to show documentation for `DigitalCrownView`, etc.
- [x] Bump CareKit dependency to ensure developers don't use a version that can crash when querying 