### PR TITLE
refactor: Update CustomLinearCareTaskProgress

### DIFF
--- a/CareKitEssentials.xcodeproj/project.pbxproj
+++ b/CareKitEssentials.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		OBJ_755 /* OCKAnyEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* OCKAnyEvent.swift */; };
 		OBJ_756 /* OCKAnyOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* OCKAnyOutcome.swift */; };
 		OBJ_757 /* OCKBiologicalSex+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* OCKBiologicalSex+Hashable.swift */; };
-		OBJ_758 /* CustomLinearCareTaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* CustomLinearCareTaskProgress.swift */; };
+		OBJ_758 /* CareTaskProgressStrategy+Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* CareTaskProgressStrategy+Math.swift */; };
 		OBJ_759 /* OCKOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* OCKOutcome.swift */; };
 		OBJ_760 /* OCKOutcomeValue+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* OCKOutcomeValue+Identifiable.swift */; };
 		OBJ_765 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* UIImage.swift */; };
@@ -140,7 +140,7 @@
 		OBJ_29 /* OCKAnyEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKAnyEvent.swift; sourceTree = "<group>"; };
 		OBJ_30 /* OCKAnyOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKAnyOutcome.swift; sourceTree = "<group>"; };
 		OBJ_31 /* OCKBiologicalSex+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKBiologicalSex+Hashable.swift"; sourceTree = "<group>"; };
-		OBJ_32 /* CustomLinearCareTaskProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLinearCareTaskProgress.swift; sourceTree = "<group>"; };
+		OBJ_32 /* CareTaskProgressStrategy+Math.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CareTaskProgressStrategy+Math.swift"; sourceTree = "<group>"; };
 		OBJ_33 /* OCKOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKOutcome.swift; sourceTree = "<group>"; };
 		OBJ_34 /* OCKOutcomeValue+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcomeValue+Identifiable.swift"; sourceTree = "<group>"; };
 		OBJ_39 /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
@@ -279,7 +279,7 @@
 			children = (
 				OBJ_26 /* Calendar+Dates.swift */,
 				911BDB272A11C491004F8442 /* CGFloat.swift */,
-				OBJ_32 /* CustomLinearCareTaskProgress.swift */,
+				OBJ_32 /* CareTaskProgressStrategy+Math.swift */,
 				OBJ_27 /* Image.swift */,
 				700DA9062C2A66BF00435E2C /* Logger.swift */,
 				70FDC6152C387C9F00A32137 /* NSImage.swift */,
@@ -562,7 +562,7 @@
 				70C422CA2C3B681A00E6DC51 /* OCKAnyOutcome+Sequence.swift in Sources */,
 				911BDB342A130AF9004F8442 /* OCKStore.swift in Sources */,
 				OBJ_757 /* OCKBiologicalSex+Hashable.swift in Sources */,
-				OBJ_758 /* CustomLinearCareTaskProgress.swift in Sources */,
+				OBJ_758 /* CareTaskProgressStrategy+Math.swift in Sources */,
 				70BBCB572A14164E00759A9C /* SliderLogTaskViewModel.swift in Sources */,
 				OBJ_759 /* OCKOutcome.swift in Sources */,
 				OBJ_760 /* OCKOutcomeValue+Identifiable.swift in Sources */,

--- a/CareKitEssentials.xcodeproj/project.pbxproj
+++ b/CareKitEssentials.xcodeproj/project.pbxproj
@@ -3,10 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4B5FB0B42C3F4A2000855675 /* CareKitEssentials.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "carekitessentials::CareKitEssentials::Product" /* CareKitEssentials.framework */; platformFilters = (ios, maccatalyst, macos, watchos, xros, ); };
+		4B5FB0C22C3F4ACB00855675 /* CareKitEssentials.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "carekitessentials::CareKitEssentials::Product" /* CareKitEssentials.framework */; platformFilters = (ios, maccatalyst, macos, watchos, xros, ); };
+		4B5FB0C82C3F4AD200855675 /* CareTaskProgressStrategynTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5FB0C02C3F4ACB00855675 /* CareTaskProgressStrategynTests.swift */; };
 		700DA9052C2A609600435E2C /* CareKitEssentialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700DA9042C2A609600435E2C /* CareKitEssentialView.swift */; };
 		700DA9072C2A66BF00435E2C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700DA9062C2A66BF00435E2C /* Logger.swift */; };
 		70BBCB472A12B8F500759A9C /* CardEnabledEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BBCB462A12B8F500759A9C /* CardEnabledEnvironmentKey.swift */; };
@@ -61,6 +64,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4B5FB0B52C3F4A2000855675 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "carekitessentials::CareKitEssentials";
+			remoteInfo = CareKitEssentials;
+		};
+		4B5FB0C32C3F4ACB00855675 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "carekitessentials::CareKitEssentials";
+			remoteInfo = CareKitEssentials;
+		};
 		70C422E12C3B6C8D00E6DC51 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -99,6 +116,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4B5FB0B02C3F4A2000855675 /* CareTaskProgressStrategyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CareTaskProgressStrategyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B5FB0BE2C3F4ACB00855675 /* CareTaskProgressStrategyExtensionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CareTaskProgressStrategyExtensionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B5FB0C02C3F4ACB00855675 /* CareTaskProgressStrategynTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareTaskProgressStrategynTests.swift; sourceTree = "<group>"; };
 		700DA8F92C29051900435E2C /* CareKitEssentials.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CareKitEssentials.xctestplan; sourceTree = "<group>"; };
 		700DA9042C2A609600435E2C /* CareKitEssentialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialView.swift; sourceTree = "<group>"; };
 		700DA9062C2A66BF00435E2C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -155,6 +175,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4B5FB0AD2C3F4A2000855675 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4B5FB0B42C3F4A2000855675 /* CareKitEssentials.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4B5FB0BB2C3F4ACB00855675 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4B5FB0C22C3F4ACB00855675 /* CareKitEssentials.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		70C422CC2C3B6C7600E6DC51 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -314,6 +350,8 @@
 				"carekitessentials::CareKitEssentials::Product" /* CareKitEssentials.framework */,
 				"carekitessentials::CareKitEssentialsTests::Product" /* CareKitEssentialsTests.xctest */,
 				70C422CF2C3B6C7600E6DC51 /* TestHost.app */,
+				4B5FB0B02C3F4A2000855675 /* CareTaskProgressStrategyTests.xctest */,
+				4B5FB0BE2C3F4ACB00855675 /* CareTaskProgressStrategyExtensionTests.xctest */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -330,6 +368,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_45 /* OCKOutcomeExtensionsTests.swift */,
+				4B5FB0C02C3F4ACB00855675 /* CareTaskProgressStrategynTests.swift */,
 			);
 			name = CareKitEssentialsTests;
 			path = Tests/CareKitEssentialsTests;
@@ -384,6 +423,42 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4B5FB0AF2C3F4A2000855675 /* CareTaskProgressStrategyTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4B5FB0B92C3F4A2000855675 /* Build configuration list for PBXNativeTarget "CareTaskProgressStrategyTests" */;
+			buildPhases = (
+				4B5FB0AC2C3F4A2000855675 /* Sources */,
+				4B5FB0AD2C3F4A2000855675 /* Frameworks */,
+				4B5FB0AE2C3F4A2000855675 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4B5FB0B62C3F4A2000855675 /* PBXTargetDependency */,
+			);
+			name = CareTaskProgressStrategyTests;
+			productName = CareTaskProgressStrategyTests;
+			productReference = 4B5FB0B02C3F4A2000855675 /* CareTaskProgressStrategyTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		4B5FB0BD2C3F4ACB00855675 /* CareTaskProgressStrategyExtensionTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4B5FB0C52C3F4ACB00855675 /* Build configuration list for PBXNativeTarget "CareTaskProgressStrategyExtensionTests" */;
+			buildPhases = (
+				4B5FB0BA2C3F4ACB00855675 /* Sources */,
+				4B5FB0BB2C3F4ACB00855675 /* Frameworks */,
+				4B5FB0BC2C3F4ACB00855675 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4B5FB0C42C3F4ACB00855675 /* PBXTargetDependency */,
+			);
+			name = CareTaskProgressStrategyExtensionTests;
+			productName = CareTaskProgressStrategyExtensionTests;
+			productReference = 4B5FB0BE2C3F4ACB00855675 /* CareTaskProgressStrategyExtensionTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		70C422CE2C3B6C7600E6DC51 /* TestHost */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 70C422DB2C3B6C7600E6DC51 /* Build configuration list for PBXNativeTarget "TestHost" */;
@@ -455,6 +530,12 @@
 				LastUpgradeCheck = 1540;
 				ORGANIZATIONNAME = "Network Reconnaissance Lab";
 				TargetAttributes = {
+					4B5FB0AF2C3F4A2000855675 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+					4B5FB0BD2C3F4ACB00855675 = {
+						CreatedOnToolsVersion = 15.4;
+					};
 					70C422CE2C3B6C7600E6DC51 = {
 						CreatedOnToolsVersion = 15.4;
 					};
@@ -482,11 +563,27 @@
 				"carekitessentials::CareKitEssentials" /* CareKitEssentials */,
 				"carekitessentials::CareKitEssentialsTests" /* CareKitEssentialsTests */,
 				70C422CE2C3B6C7600E6DC51 /* TestHost */,
+				4B5FB0AF2C3F4A2000855675 /* CareTaskProgressStrategyTests */,
+				4B5FB0BD2C3F4ACB00855675 /* CareTaskProgressStrategyExtensionTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4B5FB0AE2C3F4A2000855675 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4B5FB0BC2C3F4ACB00855675 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		70C422CD2C3B6C7600E6DC51 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -521,6 +618,20 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4B5FB0AC2C3F4A2000855675 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4B5FB0BA2C3F4ACB00855675 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		70C422CB2C3B6C7600E6DC51 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -582,12 +693,37 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_791 /* OCKOutcomeExtensionsTests.swift in Sources */,
+				4B5FB0C82C3F4AD200855675 /* CareTaskProgressStrategynTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4B5FB0B62C3F4A2000855675 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				maccatalyst,
+				macos,
+				watchos,
+				xros,
+			);
+			target = "carekitessentials::CareKitEssentials" /* CareKitEssentials */;
+			targetProxy = 4B5FB0B52C3F4A2000855675 /* PBXContainerItemProxy */;
+		};
+		4B5FB0C42C3F4ACB00855675 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				maccatalyst,
+				macos,
+				watchos,
+				xros,
+			);
+			target = "carekitessentials::CareKitEssentials" /* CareKitEssentials */;
+			targetProxy = 4B5FB0C32C3F4ACB00855675 /* PBXContainerItemProxy */;
+		};
 		70C422E22C3B6C8D00E6DC51 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "carekitessentials::CareKitEssentials" /* CareKitEssentials */;
@@ -606,6 +742,160 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		4B5FB0B72C3F4A2000855675 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "Luis-Millan.CareTaskProgressStrategyTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4B5FB0B82C3F4A2000855675 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "Luis-Millan.CareTaskProgressStrategyTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4B5FB0C62C3F4ACB00855675 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "Luis-Millan.CareTaskProgressStrategyExtensionTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4B5FB0C72C3F4ACB00855675 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "Luis-Millan.CareTaskProgressStrategyExtensionTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		70C422DC2C3B6C7600E6DC51 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -998,6 +1288,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4B5FB0B92C3F4A2000855675 /* Build configuration list for PBXNativeTarget "CareTaskProgressStrategyTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4B5FB0B72C3F4A2000855675 /* Debug */,
+				4B5FB0B82C3F4A2000855675 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4B5FB0C52C3F4ACB00855675 /* Build configuration list for PBXNativeTarget "CareTaskProgressStrategyExtensionTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4B5FB0C62C3F4ACB00855675 /* Debug */,
+				4B5FB0C72C3F4ACB00855675 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		70C422DB2C3B6C7600E6DC51 /* Build configuration list for PBXNativeTarget "TestHost" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
+++ b/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
@@ -1,6 +1,6 @@
 //
-//  OCKEventAggregator.swift
-//  
+//  CareTaskProgressStrategy+Math.swift
+//
 //
 //  Created by Corey Baker on 4/25/23.
 //
@@ -23,70 +23,6 @@ import Foundation
 ///     ProgressView(value: progress.fractionCompleted)
 /// }
 /// ```
-public struct CustomLinearCareTaskProgress: CareTaskProgress, Hashable, Sendable {
-
-    /// The progress that's been made towards reaching the goal.
-    ///
-    /// - Precondition: `value` >= 0
-    public var value: Double {
-        didSet { Self.validate(progressValue: value) }
-    }
-
-    /// A value that indicates whether the task is complete.
-    ///
-    /// When there is no goal, the value is `nil`.  The task is considered
-    /// completed if the progress value is greater than zero.
-    ///
-    /// - Precondition: `value` >= 0
-    public var goal: Double? {
-        didSet { Self.validate(goal: goal) }
-    }
-
-    public init(
-        value: Double,
-        goal: Double? = nil
-    ) {
-        Self.validate(progressValue: value)
-        Self.validate(goal: goal)
-
-        self.value = value
-        self.goal = goal
-    }
-
-    private static func validate(progressValue: Double) {
-        precondition(progressValue >= 0)
-    }
-
-    private static func validate(goal: Double?) {
-        guard let goal else { return }
-        precondition(goal >= 0)
-    }
-
-    // MARK: - CareTaskProgress
-
-    public var fractionCompleted: Double {
-
-        // If there is no goal, a non-zero progress value indicates that progress
-        // is 100% completed
-        guard let goal else {
-
-            let isCompleted = value > 0
-            let fractionCompleted: Double = isCompleted ? 1 : 0
-            return fractionCompleted
-        }
-
-        guard goal > 0 else {
-
-            // The progress value is always guaranteed to be greater than or equal to
-            // zero, so it's guaranteed to have reached the target value
-            return 1
-        }
-
-        let fractionCompleted = value / goal
-        let clampedFractionCompleted = min(fractionCompleted, 1)
-        return clampedFractionCompleted
-    }
-}
 
 public extension CareTaskProgressStrategy {
 
@@ -123,7 +59,7 @@ public extension CareTaskProgressStrategy {
         return sum
     }
 
-    static func computeProgressByAveragingOutcomeValues(for event: OCKAnyEvent) -> CustomLinearCareTaskProgress {
+    static func computeProgressByAveragingOutcomeValues(for event: OCKAnyEvent) -> LinearCareTaskProgress {
 
         let outcomeValues = event.outcome?.values ?? []
 
@@ -146,7 +82,7 @@ public extension CareTaskProgressStrategy {
             value = summedOutcomesValue / completedOutcomesValues
         }
 
-        let progress = CustomLinearCareTaskProgress(
+        let progress = LinearCareTaskProgress(
             value: value,
             goal: summedTargetValue
         )
@@ -154,7 +90,7 @@ public extension CareTaskProgressStrategy {
         return progress
     }
 
-    static func computeProgressByMedianOutcomeValues(for event: OCKAnyEvent) -> CustomLinearCareTaskProgress {
+    static func computeProgressByMedianOutcomeValues(for event: OCKAnyEvent) -> LinearCareTaskProgress {
 
         let outcomeValues = event.outcome?.values ?? []
 
@@ -181,7 +117,7 @@ public extension CareTaskProgressStrategy {
             }
         }
 
-        let progress = CustomLinearCareTaskProgress(
+        let progress = LinearCareTaskProgress(
             value: value,
             goal: summedTargetValue
         )
@@ -189,7 +125,7 @@ public extension CareTaskProgressStrategy {
         return progress
     }
 
-    static func computeProgressByStreakOutcomeValues(for event: OCKAnyEvent) -> CustomLinearCareTaskProgress {
+    static func computeProgressByStreakOutcomeValues(for event: OCKAnyEvent) -> LinearCareTaskProgress {
 
         let outcomeValues = event.outcome?.values ?? []
 
@@ -205,7 +141,7 @@ public extension CareTaskProgressStrategy {
                 return sum(partialResult, nextTarget)
             }
 
-        let progress = CustomLinearCareTaskProgress(
+        let progress = LinearCareTaskProgress(
             value: summedOutcomesValue,
             goal: summedTargetValue
         )

--- a/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
+++ b/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
@@ -73,7 +73,7 @@ public extension CareTaskProgressStrategy {
         let summedTargetValue = targetValues
             .map(accumulableDoubleValue)
             .reduce(nil) { partialResult, nextTarget -> Double? in
-                return sum(partialResult, nextTarget)
+                sum(partialResult, nextTarget)
             }
         var value = 0.0
         if completedOutcomesValues >= 1.0 {

--- a/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
+++ b/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
@@ -31,11 +31,11 @@ public extension CareTaskProgressStrategy {
 
         switch outcomeValue.type {
 
-            // These types can be converted to a double value
+        // These types can be converted to a double value
         case .double, .integer:
             return outcomeValue.numberValue!.doubleValue
 
-            // These types cannot be converted to a double value
+        // These types cannot be converted to a double value
         case .binary, .text, .date, .boolean:
             return 1
         }
@@ -83,6 +83,7 @@ public extension CareTaskProgressStrategy {
             value: value,
             goal: summedTargetValue
         )
+        print("Progress \(progress)")
 
         return progress
 

--- a/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
+++ b/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
@@ -83,7 +83,6 @@ public extension CareTaskProgressStrategy {
             value: value,
             goal: summedTargetValue
         )
-        print("Progress \(progress)")
 
         return progress
 

--- a/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
+++ b/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
@@ -108,12 +108,12 @@ public extension CareTaskProgressStrategy {
 
         var value = 0.0
         if !allOutcomesValue.isEmpty {
-            let count = allOutcomesValue.count
-            if (count % 2) == 0 {
-                let index = count / 2
+            let valueCount = allOutcomesValue.count
+            if (valueCount % 2) == 0 {
+                let index = valueCount / 2
                 value = (allOutcomesValue[index] + allOutcomesValue[index - 1]) / 2.0
             } else {
-                value = allOutcomesValue[count / 2]
+                value = allOutcomesValue[valueCount / 2]
             }
         }
 

--- a/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
+++ b/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy+Math.swift
@@ -103,7 +103,7 @@ public extension CareTaskProgressStrategy {
         let summedTargetValue = targetValues
             .map(accumulableDoubleValue)
             .reduce(nil) { partialResult, nextTarget -> Double? in
-                return sum(partialResult, nextTarget)
+                sum(partialResult, nextTarget)
             }
 
         var value = 0.0
@@ -139,7 +139,7 @@ public extension CareTaskProgressStrategy {
         let summedTargetValue = targetValues
             .map(accumulableDoubleValue)
             .reduce(nil) { partialResult, nextTarget -> Double? in
-                return sum(partialResult, nextTarget)
+                sum(partialResult, nextTarget)
             }
 
         let progress = LinearCareTaskProgress(

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -18,16 +18,16 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             occurrence: 0,
             hasOutcome: false
         )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event)
 
         XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
         XCTAssertNil(progress.goal)
     }
 
     func testProgressAveragingSingleOutcomeSingleTarget() async throws {
-        let outcomeValues = [OCKOutcomeValue(10)]
-        let targetValues = [OCKOutcomeValue(20)]
+        let outcomeValues = [OCKOutcomeValue(10.0)]
+        let targetValues = [OCKOutcomeValue(20.0)]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
             occurrence: 0,
@@ -35,19 +35,23 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues,
             targetValues: targetValues
         )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event)
         XCTAssertEqual(progress.value, 10.0, accuracy: 0.0001)
         XCTAssertEqual(progress.goal!, 20.0, accuracy: 0.0001)
     }
 
-    func testProgressAveragingMultipleOutcomesMultipleTargets() async throws {
-        let outcomeValues = [OCKOutcomeValue(10),
-                             OCKOutcomeValue(20),
-                             OCKOutcomeValue(30)]
-        let targetValues = [OCKOutcomeValue(15),
-                            OCKOutcomeValue(25),
-                            OCKOutcomeValue(35)]
+    func testProgressAveragingMultipleIntegerOutcomesMultipleTargetsDoubles() async throws {
+        let outcomeValues = [
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(30.0)
+        ]
+        let targetValues = [
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)
+        ]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
             occurrence: 0,
@@ -55,24 +59,61 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues,
             targetValues: targetValues
         )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
-        // swiftlint:disable:next line_length
-        let expectedValue = outcomeValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +) / Double(outcomeValues.count)
-        let expectedGoal = targetValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .map { $0.doubleValue ?? 0.0 }
+            .reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues
+            .map { $0.doubleValue ?? 0.0 }
+            .reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressAveragingMultipleIntegerOutcomesMultipleTargetsIntegers() async throws {
+        let outcomeValues = [
+            OCKOutcomeValue(10),
+            OCKOutcomeValue(20),
+            OCKOutcomeValue(30)
+        ]
+        let targetValues = [
+            OCKOutcomeValue(15),
+            OCKOutcomeValue(25),
+            OCKOutcomeValue(35)
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .map { $0.numberValue?.doubleValue ?? 0.0 }
+            .reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues
+            .map { $0.numberValue?.doubleValue ?? 0.0 }
+            .reduce(0, +)
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
         XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
     }
 
     func testProgressByAveragingOutcomeValuesMoreOutcomeLessTargetValues() async throws {
-        let outcomeValues = [OCKOutcomeValue(10),
-                             OCKOutcomeValue(15),
-                             OCKOutcomeValue(20),
-                             OCKOutcomeValue(30),
-                             OCKOutcomeValue(40)]
-        let targetValues = [OCKOutcomeValue(15),
-                           OCKOutcomeValue(25),
-                           OCKOutcomeValue(35)]
+        let outcomeValues = [
+         OCKOutcomeValue(10),
+         OCKOutcomeValue(15),
+         OCKOutcomeValue(20),
+         OCKOutcomeValue(30),
+         OCKOutcomeValue(40)
+        ]
+        let targetValues = [
+        OCKOutcomeValue(15),
+        OCKOutcomeValue(25),
+        OCKOutcomeValue(35)
+        ]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
             occurrence: 0,
@@ -80,13 +121,183 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues,
             targetValues: targetValues
         )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
-        // swiftlint:disable:next line_length
-        let expectedValue = outcomeValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +) / Double(outcomeValues.count)
-        let expectedGoal = targetValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .map { $0.numberValue?.doubleValue ?? 0.0 }
+            .reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues
+            .map { $0.numberValue?.doubleValue ?? 0.0 }
+            .reduce(0, +)
             XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
             XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressByAveragingOutcomeValuesZeroOutcomeTargetValues() async throws {
+        let targetValues = [
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false,
+            targetValues: targetValues
+        )
+        let progress =
+        CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event)
+            XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+            let expectedGoal = targetValues
+            .map { $0.doubleValue ?? 0.0 }
+            .reduce(0, +)
+            XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressByAveragingOutcomeValuesOutcomeValuesNoTargetValues() async throws {
+        let outcomeValues = [
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(15.0)
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .map { $0.doubleValue ?? 0.0 }
+            .reduce(0, +) / Double(outcomeValues.count)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+
+    func testProgressByAveragingOutcomeValuesWithMatchingKind() async throws {
+        var valueOfTen = OCKOutcomeValue(10.0)
+        valueOfTen.kind = "myKind"
+        var valueOfTwenty = OCKOutcomeValue(20.0)
+        valueOfTwenty.kind = "myKind"
+        var valueOfThirty = OCKOutcomeValue(30.0)
+        valueOfThirty.kind = "otherKind"
+        let outcomeValues = [
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event, kind: "myKind")
+        let filteredOutcomeValues = outcomeValues
+            .filter { $0.kind == "myKind" }
+        let completedOutcomesValues = Double(filteredOutcomeValues.count)
+        let summedOutcomesValue = filteredOutcomeValues
+            .map { $0.value as? Double ?? 0.0 }
+            .reduce(0, +)
+        let expectedValue = completedOutcomesValues >= 1.0 ? summedOutcomesValue / completedOutcomesValues : 0.0
+
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+    }
+
+    func testProgressByAveragingOutcomeValuesWithNonMatchingKinds() async throws {
+        var valueOfTen = OCKOutcomeValue(10.0)
+        valueOfTen.kind = "myKind"
+        var valueOfTwenty = OCKOutcomeValue(20.0)
+        valueOfTwenty.kind = "myKind"
+        var valueOfThirty = OCKOutcomeValue(30.0)
+        valueOfThirty.kind = "otherKind"
+
+        let outcomeValues =  [
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
+            ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event, kind: "nonMatchingKind")
+        let filteredOutcomeValues = outcomeValues
+            .filter { $0.kind == "nonMatchingKind" }
+        let completedOutcomesValues = Double(filteredOutcomeValues.count)
+        let summedOutcomesValue = filteredOutcomeValues
+            .map { $0.value as? Double ?? 0.0 }
+            .reduce(0, +)
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+
+    func testProgressByAveragingOutcomeValueWithNoNilKind() async throws {
+        var valueOfTen = OCKOutcomeValue(10.0)
+        valueOfTen.kind = "myKind"
+        var valueOfTwenty = OCKOutcomeValue(20.0)
+        valueOfTwenty.kind = "myKind"
+        var valueOfThirty = OCKOutcomeValue(30.0)
+        valueOfThirty.kind = "otherKind"
+
+        let outcomeValues = [
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
+        let filteredOutcomeValues = outcomeValues
+            .filter { $0.kind == nil }
+        let completedOutcomesValues = Double(filteredOutcomeValues.count)
+        let summedOutcomesValue = filteredOutcomeValues
+            .map { $0.value as? Double ?? 0.0 }
+            .reduce(0, +)
+        let expectedValue = completedOutcomesValues >= 1.0 ? summedOutcomesValue / completedOutcomesValues : 0.0
+
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+    }
+
+    func testProgressByAveragingOutcomeValuesWithKind() async throws {
+        var valueOfTen = OCKOutcomeValue(10.0)
+        valueOfTen.kind = nil
+        var valueOfTwenty = OCKOutcomeValue(20.0)
+        valueOfTwenty.kind = nil
+        var valueOfThirty = OCKOutcomeValue(30.0)
+        valueOfThirty.kind = "otherKind"
+        let outcomeValues = [
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
+        let filteredOutcomeValues = outcomeValues
+            .filter { $0.kind == nil }
+        let completedOutcomesValues = Double(filteredOutcomeValues.count)
+        let summedOutcomesValue = filteredOutcomeValues
+            .map { $0.value as? Double ?? 0.0 }
+            .reduce(0, +)
+        let expectedValue = completedOutcomesValues >= 1.0 ? summedOutcomesValue / completedOutcomesValues : 0.0
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByMedianOutcomeValuesNoOutcomeNoTarget() async throws {
@@ -95,14 +306,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             occurrence: 0,
             hasOutcome: false
         )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByMedianOutcomeValues(for: event)
         XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
         XCTAssertNil(progress.goal)
     }
 
     func testProgressByMedianOutcomeValuesSingleOutcomeSingleTarget() async throws {
-        let outcomeValues = [OCKOutcomeValue(10)]
-        let targetValues = [OCKOutcomeValue(15)]
+        let outcomeValues = [OCKOutcomeValue(10.0)]
+        let targetValues = [OCKOutcomeValue(15.0)]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
             occurrence: 0,
@@ -110,21 +322,30 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues,
             targetValues: targetValues
         )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
-        let expectedValue = outcomeValues.compactMap { $0.numberValue?.doubleValue }.sorted()[outcomeValues.count / 2]
-        let expectedGoal = targetValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByMedianOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .compactMap { $0.doubleValue }
+            .sorted()[outcomeValues.count / 2]
+        let expectedGoal = targetValues
+            .compactMap { $0.doubleValue }
+            .reduce(0, +)
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
         XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
 
     }
 
     func testProgressByMedianOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
-        let outcomeValues = [OCKOutcomeValue(20),
-                             OCKOutcomeValue(10),
-                             OCKOutcomeValue(30)]
-        let targetValues = [OCKOutcomeValue(15),
-                            OCKOutcomeValue(25),
-                            OCKOutcomeValue(35)]
+        let outcomeValues = [
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(30.0)
+        ]
+        let targetValues = [
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)
+        ]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
             occurrence: 0,
@@ -132,11 +353,77 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues,
             targetValues: targetValues
         )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
-        let expectedValue = outcomeValues.compactMap { $0.numberValue?.doubleValue }.sorted()[outcomeValues.count / 2]
-        let expectedGoal = targetValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByMedianOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .compactMap { $0.doubleValue }
+            .sorted()[outcomeValues.count / 2]
+        let expectedGoal = targetValues
+            .compactMap { $0.doubleValue }
+            .reduce(0, +)
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
         XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressByMedianOutcomeValuesEvenOutcomeValues() async throws {
+        let outcomeValues = [
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(10.0)
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+            )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByMedianOutcomeValues(for: event)
+        let sortedValues = outcomeValues
+            .compactMap {$0.doubleValue}
+            .sorted()
+        let expectedValue = (sortedValues[sortedValues.count / 2] + sortedValues[sortedValues.count / 2 - 1]) / 2
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+    }
+
+    func testProgressByMedianOutcomeValuesOddOutcomeValues() async throws {
+        let outcomeValues = [
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(30.0),
+            OCKOutcomeValue(20.0)
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+            )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByMedianOutcomeValues(for: event)
+        let sortedValues = outcomeValues
+            .compactMap {$0.doubleValue}
+            .sorted()
+        let expectedvalue = sortedValues[sortedValues.count / 2]
+        XCTAssertEqual(progress.value, expectedvalue, accuracy: 0.0001)
+    }
+
+    func testProgressByMedianOutcomeValuesEvenDuplicateOutcomeValues() async throws {
+        let outcomeValues = [
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(10.0)
+        ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
+            )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByMedianOutcomeValues(for: event)
+        let sortedValues = outcomeValues
+            .compactMap {$0.doubleValue}
+            .sorted()
+        let expectedValue = (sortedValues[sortedValues.count / 2] + sortedValues[sortedValues.count / 2 - 1]) / 2
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByStreakOutcomeValuesNoOutcomeNoTarget() async throws {
@@ -145,14 +432,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             occurrence: 0,
             hasOutcome: false
         )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByStreakOutcomeValues(for: event)
         XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
         XCTAssertNil(progress.goal)
     }
 
     func testProgressByStreakOutcomeValuesSingleOutcomeSingleTarget() async throws {
-        let outcomeValues = [OCKOutcomeValue(10)]
-        let targetValues = [OCKOutcomeValue(15)]
+        let outcomeValues = [OCKOutcomeValue(10.0)]
+        let targetValues = [OCKOutcomeValue(15.0)]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
             occurrence: 0,
@@ -160,21 +448,27 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues,
             targetValues: targetValues
         )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
-        // swiftlint:disable:next line_length
-        let expectedValue = outcomeValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +) / Double(outcomeValues.count)
-        let expectedGoal = targetValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByStreakOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .map { $0.doubleValue ?? 0.0 }
+            .reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues
+            .map { $0.doubleValue ?? 0.0 }
+            .reduce(0, +)
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
         XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
     }
 
     func testProgressByStreakOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
-        let outcomeValues = [OCKOutcomeValue(10),
-                             OCKOutcomeValue(20),
-                             OCKOutcomeValue(30)]
-        let targetValues = [OCKOutcomeValue(15),
-                            OCKOutcomeValue(25),
-                            OCKOutcomeValue(35)]
+        let outcomeValues = [
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(30.0)]
+        let targetValues = [
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
             occurrence: 0,
@@ -182,13 +476,17 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues,
             targetValues: targetValues
         )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
-        let expectedValue = outcomeValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
-        let expectedGoal = targetValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
+            .computeProgressByStreakOutcomeValues(for: event)
+        let expectedValue = outcomeValues
+            .compactMap { $0.doubleValue }
+            .reduce(0, +)
+        let expectedGoal = targetValues
+            .compactMap { $0.doubleValue }
+            .reduce(0, +)
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
         XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
     }
-
 }
 
 private extension OCKAnyEvent {
@@ -225,8 +523,12 @@ private extension OCKAnyEvent {
                 values: values
             ) :
             nil
-        // swiftlint:disable:next line_length
-        let event = OCKAnyEvent(task: task, outcome: outcome, scheduleEvent: schedule.event(forOccurrenceIndex: occurrence)!)
+        let event =
+        OCKAnyEvent(
+            task: task,
+            outcome: outcome,
+            scheduleEvent: schedule.event(forOccurrenceIndex: occurrence)!
+            )
 
         return event
     }

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -157,9 +157,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let kind = "myKind"
         let kind2 = "otherKind"
 
-        var valueOfTen = OCKOutcomeValue(10.0)
+        let ten = 10.0
+        let twenty = 20.0
+        var valueOfTen = OCKOutcomeValue(ten)
         valueOfTen.kind = kind
-        var valueOfTwenty = OCKOutcomeValue(20.0)
+        var valueOfTwenty = OCKOutcomeValue(twenty)
         valueOfTwenty.kind = kind
         var valueOfThirty = OCKOutcomeValue(30.0)
         valueOfThirty.kind = kind2
@@ -176,13 +178,7 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: kind)
-        let filteredOutcomeValues = outcomeValues
-            .filter { $0.kind == kind }
-        let completedOutcomesValues = Double(filteredOutcomeValues.count)
-        let summedOutcomesValue = filteredOutcomeValues
-            .map { $0.value as? Double ?? 0.0 }
-            .reduce(0, +)
-        let expectedValue = completedOutcomesValues >= 1.0 ? summedOutcomesValue / completedOutcomesValues : 0.0
+        let expectedValue = (ten / twenty) / 2
 
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
@@ -217,7 +213,7 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         XCTAssertNil(progress.goal)
     }
 
-    func testProgressByAveragingOutcomeValueWithNoNilKind() async throws {
+    func testProgressByAveragingOutcomeValueWithNonNilKind() async throws {
         let kind = "myKind"
         let kind2 = "otherKind"
 
@@ -241,23 +237,17 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
-        let filteredOutcomeValues = outcomeValues
-            .filter { $0.kind == nil }
-        let completedOutcomesValues = Double(filteredOutcomeValues.count)
-        let summedOutcomesValue = filteredOutcomeValues
-            .map { $0.value as? Double ?? 0.0 }
-            .reduce(0, +)
-        let expectedValue = completedOutcomesValues >= 1.0 ? summedOutcomesValue / completedOutcomesValues : 0.0
-
+        let expectedValue = 0.0
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByAveragingOutcomeValuesWithKind() async throws {
         let kind = "otherKind"
-
-        var valueOfTen = OCKOutcomeValue(10.0)
+        let ten  = 10.0
+        let twenty = 20.0
+        var valueOfTen = OCKOutcomeValue(ten)
         valueOfTen.kind = nil
-        var valueOfTwenty = OCKOutcomeValue(20.0)
+        var valueOfTwenty = OCKOutcomeValue(twenty)
         valueOfTwenty.kind = nil
         var valueOfThirty = OCKOutcomeValue(30.0)
         valueOfThirty.kind = kind
@@ -274,14 +264,7 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
-        let filteredOutcomeValues = outcomeValues
-            .filter { $0.kind == nil }
-        let completedOutcomesValues = Double(filteredOutcomeValues.count)
-        let summedOutcomesValue = filteredOutcomeValues
-            .map { $0.value as? Double ?? 0.0 }
-            .reduce(0, +)
-        let expectedValue = completedOutcomesValues >= 1.0 ? summedOutcomesValue / completedOutcomesValues : 0.0
-
+       let expectedValue = (ten + twenty) / 2
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
@@ -397,28 +380,6 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let expectedvalue = sortedValues[index]
 
         XCTAssertEqual(progress.value, expectedvalue, accuracy: 0.0001)
-    }
-
-    func testProgressByMedianOutcomeValuesEvenDuplicateOutcomeValues() async throws {
-        let outcomeValues = [
-            OCKOutcomeValue(10.0),
-            OCKOutcomeValue(10.0)
-        ]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
-            .computeProgressByMedianOutcomeValues(for: event)
-        let sortedValues = outcomeValues
-            .compactMap { $0.doubleValue }
-            .sorted()
-        let index = sortedValues.count / 2
-        let expectedValue = (sortedValues[index] + sortedValues[index - 1]) / 2
-
-        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByStreakOutcomeValuesNoOutcomeNoTarget() async throws {

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -10,6 +10,187 @@ import XCTest
 import CareKitStore
 @testable import CareKitEssentials
 
+final class CareTaskProgressStrategyTests: XCTestCase {
+
+    func testProgressByAveragingOutcomeValuesNoOutcomeNoTarget() async throws {
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+
+    func testProgressAveragingSingleOutcomeSingleTarget() async throws {
+        let outcomeValues = [OCKOutcomeValue(10)]
+        let targetValues = [OCKOutcomeValue(20)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+        XCTAssertEqual(progress.value, 10.0, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, 20.0, accuracy: 0.0001)
+    }
+
+    func testProgressAveragingMultipleOutcomesMultipleTargets() async throws {
+        let outcomeValues = [OCKOutcomeValue(10),
+                             OCKOutcomeValue(20),
+                             OCKOutcomeValue(30)]
+        let targetValues = [OCKOutcomeValue(15),
+                            OCKOutcomeValue(25),
+                            OCKOutcomeValue(35)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+        // swiftlint:disable:next line_length
+        let expectedValue = outcomeValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressByAveragingOutcomeValuesMoreOutcomeLessTargetValues() async throws {
+        let outcomeValues = [OCKOutcomeValue(10),
+                             OCKOutcomeValue(15),
+                             OCKOutcomeValue(20),
+                             OCKOutcomeValue(30),
+                             OCKOutcomeValue(40)]
+        let targetValues = [OCKOutcomeValue(15),
+                           OCKOutcomeValue(25),
+                           OCKOutcomeValue(35)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+        // swiftlint:disable:next line_length
+        let expectedValue = outcomeValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +)
+            XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+            XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressByMedianOutcomeValuesNoOutcomeNoTarget() async throws {
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+
+    func testProgressByMedianOutcomeValuesSingleOutcomeSingleTarget() async throws {
+        let outcomeValues = [OCKOutcomeValue(10)]
+        let targetValues = [OCKOutcomeValue(15)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
+        let expectedValue = outcomeValues.compactMap { $0.numberValue?.doubleValue }.sorted()[outcomeValues.count / 2]
+        let expectedGoal = targetValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+
+    }
+
+    func testProgressByMedianOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
+        let outcomeValues = [OCKOutcomeValue(20),
+                             OCKOutcomeValue(10),
+                             OCKOutcomeValue(30)]
+        let targetValues = [OCKOutcomeValue(15),
+                            OCKOutcomeValue(25),
+                            OCKOutcomeValue(35)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
+        let expectedValue = outcomeValues.compactMap { $0.numberValue?.doubleValue }.sorted()[outcomeValues.count / 2]
+        let expectedGoal = targetValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressByStreakOutcomeValuesNoOutcomeNoTarget() async throws {
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+
+    func testProgressByStreakOutcomeValuesSingleOutcomeSingleTarget() async throws {
+        let outcomeValues = [OCKOutcomeValue(10)]
+        let targetValues = [OCKOutcomeValue(15)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
+        // swiftlint:disable:next line_length
+        let expectedValue = outcomeValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues.map { $0.numberValue?.doubleValue ?? 0.0 }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testProgressByStreakOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
+        let outcomeValues = [OCKOutcomeValue(10),
+                             OCKOutcomeValue(20),
+                             OCKOutcomeValue(30)]
+        let targetValues = [OCKOutcomeValue(15),
+                            OCKOutcomeValue(25),
+                            OCKOutcomeValue(35)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
+        let expectedValue = outcomeValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
+        let expectedGoal = targetValues.compactMap { $0.numberValue?.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+}
+
 private extension OCKAnyEvent {
 
     static func mock(
@@ -49,172 +230,4 @@ private extension OCKAnyEvent {
 
         return event
     }
-}
-final class CareTaskProgressStrategyTests: XCTestCase {
-    // Testing computeProgressByAveragingOutcomeValues
-
-    func testcomputeProgressByAveragingOutcomeValues_NoOutcomeNoTarget() async throws {
-
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: false
-        )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
-
-        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
-        XCTAssertNil(progress.goal)
-    }
-    func testcomputeProgressByAveragingOutcomeValues_SingleOutcomeSingleTarget() async throws {
-        let outcomeValues = [OCKOutcomeValue(10)]
-        let targetValues = [OCKOutcomeValue(20)]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
-        XCTAssertEqual(progress.value, 10.0, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, 20.0, accuracy: 0.0001)
-    }
-    func testComputeProgressByAveragingOutcomeValues_MultipleOutcomesMultipleTargets() async throws {
-        let outcomeValues = [OCKOutcomeValue(10), OCKOutcomeValue(20), OCKOutcomeValue(30)]
-        let targetValues = [OCKOutcomeValue(15), OCKOutcomeValue(25), OCKOutcomeValue(35)]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
-        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +) / Double(outcomeValues.count)
-        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
-    }
-
-    func testComputeProgressByAveragingOutcomeValues_MoreOutcomeLessTargetValues() async throws {
-        let outcomeValues = [OCKOutcomeValue(10),
-                             OCKOutcomeValue(15),
-                             OCKOutcomeValue(20),
-                             OCKOutcomeValue(30),
-                             OCKOutcomeValue(40)
-                            ]
-        let targetValues = [OCKOutcomeValue(15),
-                           OCKOutcomeValue(25),
-                           OCKOutcomeValue(35)
-                            ]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        // swiftlint:disable:next line_length
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
-
-        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +) / Double(outcomeValues.count)
-            let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-            XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-            XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
-    }
-    // test computeProgressByMedianOutcomeValues
-
-    func testComputeProgressByMedianOutcomeValues_NoOutcomeNoTarget() async throws {
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: false
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
-        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
-        XCTAssertNil(progress.goal)
-    }
-
-    func testComputeProgressByMedianOutcomeValues_SingleOutcomeSingleTarget() async throws {
-        let outcomeValues = [OCKOutcomeValue(10)]
-        let targetValues = [OCKOutcomeValue(15)]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
-        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.sorted()[outcomeValues.count / 2]
-        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
-
-    }
-
-    func testComputeProgressByMedianOutcomeValues_MultipleOutcomesMultipleTargets() async throws {
-        let outcomeValues = [OCKOutcomeValue(20), OCKOutcomeValue(10), OCKOutcomeValue(30)]
-        let targetValues = [OCKOutcomeValue(15), OCKOutcomeValue(25), OCKOutcomeValue(35)]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
-        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.sorted()[outcomeValues.count / 2]
-        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
-    }
-        // testing ComputeProgressByStreakOutcomeValues
-
-    func testComputeProgressByStreakOutcomeValues_NoOutcomeNoTarget() async throws {
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: false
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
-        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
-        XCTAssertNil(progress.goal)
-    }
-    func testComputeProgressByStreakOutcomeValues_SingleOutcomeSingleTarget() async throws {
-        let outcomeValues = [OCKOutcomeValue(10)]
-        let targetValues = [OCKOutcomeValue(15)]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
-        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
-    }
-    func testComputeProgressByStreakOutcomeValues_MultipleOutcomesMultipleTargets() async throws {
-        let outcomeValues = [OCKOutcomeValue(10), OCKOutcomeValue(20), OCKOutcomeValue(30)]
-        let targetValues = [OCKOutcomeValue(15), OCKOutcomeValue(25), OCKOutcomeValue(35)]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
-        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
-        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
-    }
-
 }

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -14,9 +14,9 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByAveragingOutcomeValuesNoOutcomeNoTarget() async throws {
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: false
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -29,11 +29,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let outcomeValues = [OCKOutcomeValue(10.0)]
         let targetValues = [OCKOutcomeValue(20.0)]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -45,21 +45,21 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressAveragingOutcomesMultipleTargetsDoubles() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(10.0),
-        OCKOutcomeValue(20.0),
-        OCKOutcomeValue(30.0)
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(30.0)
         ]
         let targetValues = [
-        OCKOutcomeValue(15.0),
-        OCKOutcomeValue(25.0),
-        OCKOutcomeValue(35.0)
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -77,21 +77,21 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressAveragingMultipleIntegerOutcomesMultipleTargetsIntegers() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(10),
-        OCKOutcomeValue(20),
-        OCKOutcomeValue(30)
+            OCKOutcomeValue(10),
+            OCKOutcomeValue(20),
+            OCKOutcomeValue(30)
         ]
         let targetValues = [
-        OCKOutcomeValue(15),
-        OCKOutcomeValue(25),
-        OCKOutcomeValue(35)
+            OCKOutcomeValue(15),
+            OCKOutcomeValue(25),
+            OCKOutcomeValue(35)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -110,15 +110,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByAveragingOutcomeValuesZeroOutcomeTargetValues() async throws {
         let targetValues = [
-        OCKOutcomeValue(15.0),
-        OCKOutcomeValue(25.0),
-        OCKOutcomeValue(35.0)
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: false,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -133,15 +133,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByAveragingOutcomeValuesOutcomeValuesNoTargetValues() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(10.0),
-        OCKOutcomeValue(20.0),
-        OCKOutcomeValue(15.0)
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(15.0)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -164,15 +164,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         var valueOfThirty = OCKOutcomeValue(30.0)
         valueOfThirty.kind = kind2
         let outcomeValues = [
-        valueOfTen,
-        valueOfTwenty,
-        valueOfThirty
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: kind)
@@ -200,15 +200,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         valueOfThirty.kind = kind2
 
         let outcomeValues =  [
-        valueOfTen,
-        valueOfTwenty,
-        valueOfThirty
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: kind3)
@@ -229,15 +229,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         valueOfThirty.kind = kind2
 
         let outcomeValues = [
-        valueOfTen,
-        valueOfTwenty,
-        valueOfThirty
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
@@ -262,15 +262,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         var valueOfThirty = OCKOutcomeValue(30.0)
         valueOfThirty.kind = kind
         let outcomeValues = [
-        valueOfTen,
-        valueOfTwenty,
-        valueOfThirty
+            valueOfTen,
+            valueOfTwenty,
+            valueOfThirty
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
@@ -287,9 +287,9 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByMedianOutcomeValuesNoOutcomeNoTarget() async throws {
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: false
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -301,11 +301,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let outcomeValues = [OCKOutcomeValue(10.0)]
         let targetValues = [OCKOutcomeValue(15.0)]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -324,21 +324,21 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByMedianOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(20.0),
-        OCKOutcomeValue(10.0),
-        OCKOutcomeValue(30.0)
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(30.0)
         ]
         let targetValues = [
-        OCKOutcomeValue(15.0),
-        OCKOutcomeValue(25.0),
-        OCKOutcomeValue(35.0)
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -356,36 +356,37 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByMedianOutcomeValuesEvenOutcomeValues() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(20.0),
-        OCKOutcomeValue(10.0)
+            OCKOutcomeValue(20),
+            OCKOutcomeValue(10)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
         let sortedValues = outcomeValues
             .compactMap {$0.doubleValue}
             .sorted()
-        let expectedValue = (sortedValues[sortedValues.count / 2] + sortedValues[sortedValues.count / 2 - 1]) / 2
+        // swiftlint:disable:next line_length
+        let expectedValue = (sortedValues[sortedValues.count / 2.0] + sortedValues[sortedValues.count / 2.0 - 1.0]) / 2.0
 
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByMedianOutcomeValuesOddOutcomeValues() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(10.0),
-        OCKOutcomeValue(30.0),
-        OCKOutcomeValue(20.0)
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(30.0),
+            OCKOutcomeValue(20.0)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -399,14 +400,14 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByMedianOutcomeValuesEvenDuplicateOutcomeValues() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(10.0),
-        OCKOutcomeValue(10.0)
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(10.0)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -420,9 +421,9 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByStreakOutcomeValuesNoOutcomeNoTarget() async throws {
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: false
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByStreakOutcomeValues(for: event)
@@ -435,11 +436,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let outcomeValues = [OCKOutcomeValue(10.0)]
         let targetValues = [OCKOutcomeValue(15.0)]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByStreakOutcomeValues(for: event)
@@ -457,21 +458,21 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByStreakOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
         let outcomeValues = [
-        OCKOutcomeValue(10.0),
-        OCKOutcomeValue(20.0),
-        OCKOutcomeValue(30.0)
+            OCKOutcomeValue(10.0),
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(30.0)
         ]
         let targetValues = [
-        OCKOutcomeValue(15.0),
-        OCKOutcomeValue(25.0),
-        OCKOutcomeValue(35.0)
+            OCKOutcomeValue(15.0),
+            OCKOutcomeValue(25.0),
+            OCKOutcomeValue(35.0)
         ]
         let event = OCKAnyEvent.mock(
-        taskUUID: UUID(),
-        occurrence: 0,
-        hasOutcome: true,
-        values: outcomeValues,
-        targetValues: targetValues
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByStreakOutcomeValues(for: event)
@@ -500,33 +501,31 @@ private extension OCKAnyEvent {
     ) -> Self {
         let startOfDay = Calendar.current.startOfDay(for: Date())
         let schedule = OCKSchedule.dailyAtTime(
-        hour: 1,
-        minutes: 0,
-        start: startOfDay,
-        end: nil,
-        text: nil,
-        targetValues: targetValues
+            hour: 1,
+            minutes: 0,
+            start: startOfDay,
+            end: nil,
+            text: nil,
+            targetValues: targetValues
         )
         var task = OCKTask(
-        id: taskUUID.uuidString,
-        title: taskTitle,
-        carePlanUUID: nil,
-        schedule: schedule
+            id: taskUUID.uuidString,
+            title: taskTitle,
+            carePlanUUID: nil,
+            schedule: schedule
         )
         task.uuid = taskUUID
 
-        let outcome = hasOutcome ?
-        OCKOutcome(
+        let outcome = hasOutcome ? OCKOutcome(
             taskUUID: task.uuid,
             taskOccurrenceIndex: occurrence,
             values: values
         ) :
             nil
-        let event =
-        OCKAnyEvent(
-        task: task,
-        outcome: outcome,
-        scheduleEvent: schedule.event(forOccurrenceIndex: occurrence)!
+        let event = OCKAnyEvent(
+            task: task,
+            outcome: outcome,
+            scheduleEvent: schedule.event(forOccurrenceIndex: occurrence)!
         )
 
         return event

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -156,12 +156,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
     func testProgressByAveragingOutcomeValuesWithMatchingKind() async throws {
         let kind = "myKind"
         let kind2 = "otherKind"
-
         let ten = 10.0
         let twenty = 20.0
-        var valueOfTen = OCKOutcomeValue(ten)
+        var valueOfTen = OCKOutcomeValue(10.0)
         valueOfTen.kind = kind
-        var valueOfTwenty = OCKOutcomeValue(twenty)
+        var valueOfTwenty = OCKOutcomeValue(20.0)
         valueOfTwenty.kind = kind
         var valueOfThirty = OCKOutcomeValue(30.0)
         valueOfThirty.kind = kind2
@@ -177,8 +176,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
-            .computeProgressByAveragingOutcomeValues(for: event, kind: kind)
-        let expectedValue = (ten / twenty) / 2
+            .computeProgressByAveragingOutcomeValues(
+                for: event,
+                kind: kind
+            )
+        let expectedValue = (ten + twenty) / 2.0
 
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
@@ -245,11 +247,12 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let kind = "otherKind"
         let ten  = 10.0
         let twenty = 20.0
+        let thirty = 30.0
         var valueOfTen = OCKOutcomeValue(ten)
         valueOfTen.kind = nil
         var valueOfTwenty = OCKOutcomeValue(twenty)
         valueOfTwenty.kind = nil
-        var valueOfThirty = OCKOutcomeValue(30.0)
+        var valueOfThirty = OCKOutcomeValue(thirty)
         valueOfThirty.kind = kind
         let outcomeValues = [
             valueOfTen,
@@ -263,8 +266,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
-            .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
-       let expectedValue = (ten + twenty) / 2
+            .computeProgressByAveragingOutcomeValues(
+                for: event,
+                kind: kind
+            )
+       let expectedValue = thirty
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -14,9 +14,9 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByAveragingOutcomeValuesNoOutcomeNoTarget() async throws {
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: false
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: false
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -29,35 +29,37 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let outcomeValues = [OCKOutcomeValue(10.0)]
         let targetValues = [OCKOutcomeValue(20.0)]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues,
+        targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
+        let goal = try XCTUnwrap(progress.goal)
+
         XCTAssertEqual(progress.value, 10.0, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, 20.0, accuracy: 0.0001)
+        XCTAssertEqual(goal, 20.0, accuracy: 0.0001)
     }
 
-    func testProgressAveragingMultipleIntegerOutcomesMultipleTargetsDoubles() async throws {
+    func testProgressAveragingOutcomesMultipleTargetsDoubles() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(10.0),
-            OCKOutcomeValue(20.0),
-            OCKOutcomeValue(30.0)
+        OCKOutcomeValue(10.0),
+        OCKOutcomeValue(20.0),
+        OCKOutcomeValue(30.0)
         ]
         let targetValues = [
-            OCKOutcomeValue(15.0),
-            OCKOutcomeValue(25.0),
-            OCKOutcomeValue(35.0)
+        OCKOutcomeValue(15.0),
+        OCKOutcomeValue(25.0),
+        OCKOutcomeValue(35.0)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues,
+        targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -67,47 +69,17 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let expectedGoal = targetValues
             .map { $0.doubleValue ?? 0.0 }
             .reduce(0, +)
+        let goal = try XCTUnwrap(progress.goal)
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+        XCTAssertEqual(goal, expectedGoal, accuracy: 0.0001 )
     }
 
     func testProgressAveragingMultipleIntegerOutcomesMultipleTargetsIntegers() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(10),
-            OCKOutcomeValue(20),
-            OCKOutcomeValue(30)
-        ]
-        let targetValues = [
-            OCKOutcomeValue(15),
-            OCKOutcomeValue(25),
-            OCKOutcomeValue(35)
-        ]
-        let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
-        )
-        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
-            .computeProgressByAveragingOutcomeValues(for: event)
-        let expectedValue = outcomeValues
-            .map { $0.numberValue?.doubleValue ?? 0.0 }
-            .reduce(0, +) / Double(outcomeValues.count)
-        let expectedGoal = targetValues
-            .map { $0.numberValue?.doubleValue ?? 0.0 }
-            .reduce(0, +)
-        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
-    }
-
-    func testProgressByAveragingOutcomeValuesMoreOutcomeLessTargetValues() async throws {
-        let outcomeValues = [
-         OCKOutcomeValue(10),
-         OCKOutcomeValue(15),
-         OCKOutcomeValue(20),
-         OCKOutcomeValue(30),
-         OCKOutcomeValue(40)
+        OCKOutcomeValue(10),
+        OCKOutcomeValue(20),
+        OCKOutcomeValue(30)
         ]
         let targetValues = [
         OCKOutcomeValue(15),
@@ -115,11 +87,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         OCKOutcomeValue(35)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues,
+        targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
@@ -129,75 +101,83 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let expectedGoal = targetValues
             .map { $0.numberValue?.doubleValue ?? 0.0 }
             .reduce(0, +)
-            XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-            XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+        let goal = try XCTUnwrap(progress.goal)
+
+        XCTAssertEqual(goal, expectedGoal, accuracy: 0.0001)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+
     }
 
     func testProgressByAveragingOutcomeValuesZeroOutcomeTargetValues() async throws {
         let targetValues = [
-            OCKOutcomeValue(15.0),
-            OCKOutcomeValue(25.0),
-            OCKOutcomeValue(35.0)
+        OCKOutcomeValue(15.0),
+        OCKOutcomeValue(25.0),
+        OCKOutcomeValue(35.0)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: false,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: false,
+        targetValues: targetValues
         )
-        let progress =
-        CareTaskProgressStrategy<LinearCareTaskProgress>
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
-            XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
-            let expectedGoal = targetValues
+        let expectedGoal = targetValues
             .map { $0.doubleValue ?? 0.0 }
             .reduce(0, +)
-            XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+        let goal = try XCTUnwrap(progress.goal)
+
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(goal, expectedGoal, accuracy: 0.0001)
     }
 
     func testProgressByAveragingOutcomeValuesOutcomeValuesNoTargetValues() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(10.0),
-            OCKOutcomeValue(20.0),
-            OCKOutcomeValue(15.0)
+        OCKOutcomeValue(10.0),
+        OCKOutcomeValue(20.0),
+        OCKOutcomeValue(15.0)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event)
         let expectedValue = outcomeValues
             .map { $0.doubleValue ?? 0.0 }
             .reduce(0, +) / Double(outcomeValues.count)
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
         XCTAssertNil(progress.goal)
     }
 
     func testProgressByAveragingOutcomeValuesWithMatchingKind() async throws {
+        let kind = "myKind"
+        let kind2 = "otherKind"
+
         var valueOfTen = OCKOutcomeValue(10.0)
-        valueOfTen.kind = "myKind"
+        valueOfTen.kind = kind
         var valueOfTwenty = OCKOutcomeValue(20.0)
-        valueOfTwenty.kind = "myKind"
+        valueOfTwenty.kind = kind
         var valueOfThirty = OCKOutcomeValue(30.0)
-        valueOfThirty.kind = "otherKind"
+        valueOfThirty.kind = kind2
         let outcomeValues = [
-            valueOfTen,
-            valueOfTwenty,
-            valueOfThirty
+        valueOfTen,
+        valueOfTwenty,
+        valueOfThirty
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
-            .computeProgressByAveragingOutcomeValues(for: event, kind: "myKind")
+            .computeProgressByAveragingOutcomeValues(for: event, kind: kind)
         let filteredOutcomeValues = outcomeValues
-            .filter { $0.kind == "myKind" }
+            .filter { $0.kind == kind }
         let completedOutcomesValues = Double(filteredOutcomeValues.count)
         let summedOutcomesValue = filteredOutcomeValues
             .map { $0.value as? Double ?? 0.0 }
@@ -208,54 +188,56 @@ final class CareTaskProgressStrategyTests: XCTestCase {
     }
 
     func testProgressByAveragingOutcomeValuesWithNonMatchingKinds() async throws {
+        let kind = "myKind"
+        let kind2 = "otherKind"
+        let kind3 = "nonMatchingKind"
+
         var valueOfTen = OCKOutcomeValue(10.0)
-        valueOfTen.kind = "myKind"
+        valueOfTen.kind = kind
         var valueOfTwenty = OCKOutcomeValue(20.0)
-        valueOfTwenty.kind = "myKind"
+        valueOfTwenty.kind = kind
         var valueOfThirty = OCKOutcomeValue(30.0)
-        valueOfThirty.kind = "otherKind"
+        valueOfThirty.kind = kind2
 
         let outcomeValues =  [
-            valueOfTen,
-            valueOfTwenty,
-            valueOfThirty
-            ]
+        valueOfTen,
+        valueOfTwenty,
+        valueOfThirty
+        ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
-            .computeProgressByAveragingOutcomeValues(for: event, kind: "nonMatchingKind")
-        let filteredOutcomeValues = outcomeValues
-            .filter { $0.kind == "nonMatchingKind" }
-        let completedOutcomesValues = Double(filteredOutcomeValues.count)
-        let summedOutcomesValue = filteredOutcomeValues
-            .map { $0.value as? Double ?? 0.0 }
-            .reduce(0, +)
+            .computeProgressByAveragingOutcomeValues(for: event, kind: kind3)
+
         XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
         XCTAssertNil(progress.goal)
     }
 
     func testProgressByAveragingOutcomeValueWithNoNilKind() async throws {
+        let kind = "myKind"
+        let kind2 = "otherKind"
+
         var valueOfTen = OCKOutcomeValue(10.0)
-        valueOfTen.kind = "myKind"
+        valueOfTen.kind = kind
         var valueOfTwenty = OCKOutcomeValue(20.0)
-        valueOfTwenty.kind = "myKind"
+        valueOfTwenty.kind = kind
         var valueOfThirty = OCKOutcomeValue(30.0)
-        valueOfThirty.kind = "otherKind"
+        valueOfThirty.kind = kind2
 
         let outcomeValues = [
-            valueOfTen,
-            valueOfTwenty,
-            valueOfThirty
+        valueOfTen,
+        valueOfTwenty,
+        valueOfThirty
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
@@ -271,22 +253,24 @@ final class CareTaskProgressStrategyTests: XCTestCase {
     }
 
     func testProgressByAveragingOutcomeValuesWithKind() async throws {
+        let kind = "otherKind"
+
         var valueOfTen = OCKOutcomeValue(10.0)
         valueOfTen.kind = nil
         var valueOfTwenty = OCKOutcomeValue(20.0)
         valueOfTwenty.kind = nil
         var valueOfThirty = OCKOutcomeValue(30.0)
-        valueOfThirty.kind = "otherKind"
+        valueOfThirty.kind = kind
         let outcomeValues = [
-            valueOfTen,
-            valueOfTwenty,
-            valueOfThirty
+        valueOfTen,
+        valueOfTwenty,
+        valueOfThirty
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByAveragingOutcomeValues(for: event, kind: nil)
@@ -297,14 +281,15 @@ final class CareTaskProgressStrategyTests: XCTestCase {
             .map { $0.value as? Double ?? 0.0 }
             .reduce(0, +)
         let expectedValue = completedOutcomesValues >= 1.0 ? summedOutcomesValue / completedOutcomesValues : 0.0
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByMedianOutcomeValuesNoOutcomeNoTarget() async throws {
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: false
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: false
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -316,11 +301,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let outcomeValues = [OCKOutcomeValue(10.0)]
         let targetValues = [OCKOutcomeValue(15.0)]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues,
+        targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -330,28 +315,30 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let expectedGoal = targetValues
             .compactMap { $0.doubleValue }
             .reduce(0, +)
+        let goal = try XCTUnwrap(progress.goal)
+
+        XCTAssertEqual(goal, expectedGoal, accuracy: 0.0001)
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
 
     }
 
     func testProgressByMedianOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(20.0),
-            OCKOutcomeValue(10.0),
-            OCKOutcomeValue(30.0)
+        OCKOutcomeValue(20.0),
+        OCKOutcomeValue(10.0),
+        OCKOutcomeValue(30.0)
         ]
         let targetValues = [
-            OCKOutcomeValue(15.0),
-            OCKOutcomeValue(25.0),
-            OCKOutcomeValue(35.0)
+        OCKOutcomeValue(15.0),
+        OCKOutcomeValue(25.0),
+        OCKOutcomeValue(35.0)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues,
+        targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
@@ -361,79 +348,85 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let expectedGoal = targetValues
             .compactMap { $0.doubleValue }
             .reduce(0, +)
+        let goal = try XCTUnwrap(progress.goal)
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+        XCTAssertEqual(goal, expectedGoal, accuracy: 0.0001)
     }
 
     func testProgressByMedianOutcomeValuesEvenOutcomeValues() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(20.0),
-            OCKOutcomeValue(10.0)
+        OCKOutcomeValue(20.0),
+        OCKOutcomeValue(10.0)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
-            )
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
+        )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
         let sortedValues = outcomeValues
             .compactMap {$0.doubleValue}
             .sorted()
         let expectedValue = (sortedValues[sortedValues.count / 2] + sortedValues[sortedValues.count / 2 - 1]) / 2
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByMedianOutcomeValuesOddOutcomeValues() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(10.0),
-            OCKOutcomeValue(30.0),
-            OCKOutcomeValue(20.0)
+        OCKOutcomeValue(10.0),
+        OCKOutcomeValue(30.0),
+        OCKOutcomeValue(20.0)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
-            )
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
+        )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
         let sortedValues = outcomeValues
             .compactMap {$0.doubleValue}
             .sorted()
         let expectedvalue = sortedValues[sortedValues.count / 2]
+
         XCTAssertEqual(progress.value, expectedvalue, accuracy: 0.0001)
     }
 
     func testProgressByMedianOutcomeValuesEvenDuplicateOutcomeValues() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(10.0),
-            OCKOutcomeValue(10.0)
+        OCKOutcomeValue(10.0),
+        OCKOutcomeValue(10.0)
         ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues
-            )
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues
+        )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
         let sortedValues = outcomeValues
             .compactMap {$0.doubleValue}
             .sorted()
         let expectedValue = (sortedValues[sortedValues.count / 2] + sortedValues[sortedValues.count / 2 - 1]) / 2
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
 
     func testProgressByStreakOutcomeValuesNoOutcomeNoTarget() async throws {
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: false
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: false
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByStreakOutcomeValues(for: event)
+
         XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
         XCTAssertNil(progress.goal)
     }
@@ -442,11 +435,11 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let outcomeValues = [OCKOutcomeValue(10.0)]
         let targetValues = [OCKOutcomeValue(15.0)]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues,
+        targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByStreakOutcomeValues(for: event)
@@ -456,25 +449,29 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let expectedGoal = targetValues
             .map { $0.doubleValue ?? 0.0 }
             .reduce(0, +)
+        let goal = try XCTUnwrap(progress.goal)
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+        XCTAssertEqual(goal, expectedGoal, accuracy: 0.0001)
     }
 
     func testProgressByStreakOutcomeValuesMultipleOutcomesMultipleTargets() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(10.0),
-            OCKOutcomeValue(20.0),
-            OCKOutcomeValue(30.0)]
+        OCKOutcomeValue(10.0),
+        OCKOutcomeValue(20.0),
+        OCKOutcomeValue(30.0)
+        ]
         let targetValues = [
-            OCKOutcomeValue(15.0),
-            OCKOutcomeValue(25.0),
-            OCKOutcomeValue(35.0)]
+        OCKOutcomeValue(15.0),
+        OCKOutcomeValue(25.0),
+        OCKOutcomeValue(35.0)
+        ]
         let event = OCKAnyEvent.mock(
-            taskUUID: UUID(),
-            occurrence: 0,
-            hasOutcome: true,
-            values: outcomeValues,
-            targetValues: targetValues
+        taskUUID: UUID(),
+        occurrence: 0,
+        hasOutcome: true,
+        values: outcomeValues,
+        targetValues: targetValues
         )
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByStreakOutcomeValues(for: event)
@@ -484,8 +481,10 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let expectedGoal = targetValues
             .compactMap { $0.doubleValue }
             .reduce(0, +)
+        let goal = try XCTUnwrap(progress.goal)
+
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
-        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+        XCTAssertEqual(goal, expectedGoal, accuracy: 0.0001)
     }
 }
 
@@ -501,34 +500,34 @@ private extension OCKAnyEvent {
     ) -> Self {
         let startOfDay = Calendar.current.startOfDay(for: Date())
         let schedule = OCKSchedule.dailyAtTime(
-            hour: 1,
-            minutes: 0,
-            start: startOfDay,
-            end: nil,
-            text: nil,
-            targetValues: targetValues
+        hour: 1,
+        minutes: 0,
+        start: startOfDay,
+        end: nil,
+        text: nil,
+        targetValues: targetValues
         )
         var task = OCKTask(
-            id: taskUUID.uuidString,
-            title: taskTitle,
-            carePlanUUID: nil,
-            schedule: schedule
+        id: taskUUID.uuidString,
+        title: taskTitle,
+        carePlanUUID: nil,
+        schedule: schedule
         )
         task.uuid = taskUUID
 
         let outcome = hasOutcome ?
-            OCKOutcome(
-                taskUUID: task.uuid,
-                taskOccurrenceIndex: occurrence,
-                values: values
-            ) :
+        OCKOutcome(
+            taskUUID: task.uuid,
+            taskOccurrenceIndex: occurrence,
+            values: values
+        ) :
             nil
         let event =
         OCKAnyEvent(
-            task: task,
-            outcome: outcome,
-            scheduleEvent: schedule.event(forOccurrenceIndex: occurrence)!
-            )
+        task: task,
+        outcome: outcome,
+        scheduleEvent: schedule.event(forOccurrenceIndex: occurrence)!
+        )
 
         return event
     }

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -108,7 +108,7 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     }
 
-    func testProgressByAveragingOutcomeValuesZeroOutcomeTargetValues() async throws {
+    func testProgressByAveragingOutcomeValuesNoOutcomeTargetValues() async throws {
         let targetValues = [
             OCKOutcomeValue(15.0),
             OCKOutcomeValue(25.0),

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -356,8 +356,8 @@ final class CareTaskProgressStrategyTests: XCTestCase {
 
     func testProgressByMedianOutcomeValuesEvenOutcomeValues() async throws {
         let outcomeValues = [
-            OCKOutcomeValue(20),
-            OCKOutcomeValue(10)
+            OCKOutcomeValue(20.0),
+            OCKOutcomeValue(10.0)
         ]
         let event = OCKAnyEvent.mock(
             taskUUID: UUID(),
@@ -368,10 +368,10 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
         let sortedValues = outcomeValues
-            .compactMap {$0.doubleValue}
+            .compactMap { $0.doubleValue }
             .sorted()
-        // swiftlint:disable:next line_length
-        let expectedValue = (sortedValues[sortedValues.count / 2.0] + sortedValues[sortedValues.count / 2.0 - 1.0]) / 2.0
+        let index = outcomeValues.count / 2
+        let expectedValue = (sortedValues[index] + sortedValues[index - 1]) / 2.0
 
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }
@@ -391,9 +391,10 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
         let sortedValues = outcomeValues
-            .compactMap {$0.doubleValue}
+            .compactMap { $0.doubleValue }
             .sorted()
-        let expectedvalue = sortedValues[sortedValues.count / 2]
+        let index = sortedValues.count / 2
+        let expectedvalue = sortedValues[index]
 
         XCTAssertEqual(progress.value, expectedvalue, accuracy: 0.0001)
     }
@@ -412,9 +413,10 @@ final class CareTaskProgressStrategyTests: XCTestCase {
         let progress = CareTaskProgressStrategy<LinearCareTaskProgress>
             .computeProgressByMedianOutcomeValues(for: event)
         let sortedValues = outcomeValues
-            .compactMap {$0.doubleValue}
+            .compactMap { $0.doubleValue }
             .sorted()
-        let expectedValue = (sortedValues[sortedValues.count / 2] + sortedValues[sortedValues.count / 2 - 1]) / 2
+        let index = sortedValues.count / 2
+        let expectedValue = (sortedValues[index] + sortedValues[index - 1]) / 2
 
         XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
     }

--- a/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
+++ b/Tests/CareKitEssentialsTests/CareTaskProgressStrategynTests.swift
@@ -1,0 +1,220 @@
+//
+//  CareTaskProgressStrategyTests.swift
+//  CareTaskProgressStrategyTests
+//
+//  Created by Luis Millan on 7/10/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import XCTest
+import CareKitStore
+@testable import CareKitEssentials
+
+private extension OCKAnyEvent {
+
+    static func mock(
+        taskUUID: UUID,
+        occurrence: Int,
+        taskTitle: String? = nil,
+        hasOutcome: Bool = false,
+        values: [OCKOutcomeValue] = [],
+        targetValues: [OCKOutcomeValue] = []
+    ) -> Self {
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let schedule = OCKSchedule.dailyAtTime(
+            hour: 1,
+            minutes: 0,
+            start: startOfDay,
+            end: nil,
+            text: nil,
+            targetValues: targetValues
+        )
+        var task = OCKTask(
+            id: taskUUID.uuidString,
+            title: taskTitle,
+            carePlanUUID: nil,
+            schedule: schedule
+        )
+        task.uuid = taskUUID
+
+        let outcome = hasOutcome ?
+            OCKOutcome(
+                taskUUID: task.uuid,
+                taskOccurrenceIndex: occurrence,
+                values: values
+            ) :
+            nil
+        // swiftlint:disable:next line_length
+        let event = OCKAnyEvent(task: task, outcome: outcome, scheduleEvent: schedule.event(forOccurrenceIndex: occurrence)!)
+
+        return event
+    }
+}
+final class CareTaskProgressStrategyTests: XCTestCase {
+    // Testing computeProgressByAveragingOutcomeValues
+
+    func testcomputeProgressByAveragingOutcomeValues_NoOutcomeNoTarget() async throws {
+
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+    func testcomputeProgressByAveragingOutcomeValues_SingleOutcomeSingleTarget() async throws {
+        let outcomeValues = [OCKOutcomeValue(10)]
+        let targetValues = [OCKOutcomeValue(20)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+        XCTAssertEqual(progress.value, 10.0, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, 20.0, accuracy: 0.0001)
+    }
+    func testComputeProgressByAveragingOutcomeValues_MultipleOutcomesMultipleTargets() async throws {
+        let outcomeValues = [OCKOutcomeValue(10), OCKOutcomeValue(20), OCKOutcomeValue(30)]
+        let targetValues = [OCKOutcomeValue(15), OCKOutcomeValue(25), OCKOutcomeValue(35)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +) / Double(outcomeValues.count)
+        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+    func testComputeProgressByAveragingOutcomeValues_MoreOutcomeLessTargetValues() async throws {
+        let outcomeValues = [OCKOutcomeValue(10),
+                             OCKOutcomeValue(15),
+                             OCKOutcomeValue(20),
+                             OCKOutcomeValue(30),
+                             OCKOutcomeValue(40)
+                            ]
+        let targetValues = [OCKOutcomeValue(15),
+                           OCKOutcomeValue(25),
+                           OCKOutcomeValue(35)
+                            ]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        // swiftlint:disable:next line_length
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByAveragingOutcomeValues(for: event)
+
+        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +) / Double(outcomeValues.count)
+            let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+            XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+            XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+    // test computeProgressByMedianOutcomeValues
+
+    func testComputeProgressByMedianOutcomeValues_NoOutcomeNoTarget() async throws {
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+
+    func testComputeProgressByMedianOutcomeValues_SingleOutcomeSingleTarget() async throws {
+        let outcomeValues = [OCKOutcomeValue(10)]
+        let targetValues = [OCKOutcomeValue(15)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
+        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.sorted()[outcomeValues.count / 2]
+        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+
+    }
+
+    func testComputeProgressByMedianOutcomeValues_MultipleOutcomesMultipleTargets() async throws {
+        let outcomeValues = [OCKOutcomeValue(20), OCKOutcomeValue(10), OCKOutcomeValue(30)]
+        let targetValues = [OCKOutcomeValue(15), OCKOutcomeValue(25), OCKOutcomeValue(35)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByMedianOutcomeValues(for: event)
+        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.sorted()[outcomeValues.count / 2]
+        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+        // testing ComputeProgressByStreakOutcomeValues
+
+    func testComputeProgressByStreakOutcomeValues_NoOutcomeNoTarget() async throws {
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: false
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
+        XCTAssertEqual(progress.value, 0.0, accuracy: 0.0001)
+        XCTAssertNil(progress.goal)
+    }
+    func testComputeProgressByStreakOutcomeValues_SingleOutcomeSingleTarget() async throws {
+        let outcomeValues = [OCKOutcomeValue(10)]
+        let targetValues = [OCKOutcomeValue(15)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
+        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+    func testComputeProgressByStreakOutcomeValues_MultipleOutcomesMultipleTargets() async throws {
+        let outcomeValues = [OCKOutcomeValue(10), OCKOutcomeValue(20), OCKOutcomeValue(30)]
+        let targetValues = [OCKOutcomeValue(15), OCKOutcomeValue(25), OCKOutcomeValue(35)]
+        let event = OCKAnyEvent.mock(
+            taskUUID: UUID(),
+            occurrence: 0,
+            hasOutcome: true,
+            values: outcomeValues,
+            targetValues: targetValues
+        )
+        let progress = CareTaskProgressStrategy<LinearCareTaskProgress>.computeProgressByStreakOutcomeValues(for: event)
+        let expectedValue = outcomeValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+        let expectedGoal = targetValues.map { $0.numberValue!.doubleValue }.reduce(0, +)
+        XCTAssertEqual(progress.value, expectedValue, accuracy: 0.0001)
+        XCTAssertEqual(progress.goal!, expectedGoal, accuracy: 0.0001)
+    }
+
+}

--- a/Tests/CareKitEssentialsTests/OCKOutcomeExtensionsTests.swift
+++ b/Tests/CareKitEssentialsTests/OCKOutcomeExtensionsTests.swift
@@ -2,6 +2,8 @@ import XCTest
 import CareKitStore
 @testable import CareKitEssentials
 
+// add an argument that takes values: [OCKOutcomeValue] and pass it to the OCKOutcome instance
+
 final class OCKOutcomeExtensionsTests: XCTestCase {
 
     func testSortedNewestToOldestOptionalKeyPath() async throws {
@@ -96,4 +98,40 @@ final class OCKOutcomeExtensionsTests: XCTestCase {
         XCTAssertEqual(sortedByOccurrenceIndex3.first, secondOutcome)
         XCTAssertEqual(sortedByOccurrenceIndex3.last, firstOutcome)
     }
+    // swiftlint:disable:next line_length
+    // functions to test: computeProgressByAveragingOutcomeValues, computeProgressByMedianOutcomeValues, computeProgressByStreakOutcomeValues
+
 }
+
+/*
+ 
+ gets the outcomeValues of the event, if there is no outcome values then we return an empty array
+  let outcomeValues = event.outcome?.values ?? []
+
+  counts the number of outcomeValues
+  let completedOutcomesValues = Double(outcomeValues.count)
+ 
+ sums up the outcome values after converting them into a double
+ let summedOutcomesValue = outcomeValues
+     .map(accumulableDoubleValue)
+     .reduce(0, +)
+ 
+ 
+ gets target values of an event and sums them up
+ let targetValues = event.scheduleEvent.element.targetValues
+
+ let summedTargetValue = targetValues
+     .map(accumulableDoubleValue)
+     .reduce(nil) { partialResult, nextTarget -> Double? in
+         return sum(partialResult, nextTarget)
+ 
+ if there is at least one outcome value, get the average
+ var value = 0.0
+ if completedOutcomesValues >= 1.0 {
+     value = summedOutcomesValue / completedOutcomesValues
+ 
+ creates a LinearCareTaskProgress with the calculated average value and summed target value
+ let progress = LinearCareTaskProgress(
+     value: value,
+     goal: summedTargetValue
+ */

--- a/Tests/CareKitEssentialsTests/OCKOutcomeExtensionsTests.swift
+++ b/Tests/CareKitEssentialsTests/OCKOutcomeExtensionsTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import CareKitStore
 @testable import CareKitEssentials
 
-// add an argument that takes values: [OCKOutcomeValue] and pass it to the OCKOutcome instance
-
 final class OCKOutcomeExtensionsTests: XCTestCase {
 
     func testSortedNewestToOldestOptionalKeyPath() async throws {
@@ -98,40 +96,4 @@ final class OCKOutcomeExtensionsTests: XCTestCase {
         XCTAssertEqual(sortedByOccurrenceIndex3.first, secondOutcome)
         XCTAssertEqual(sortedByOccurrenceIndex3.last, firstOutcome)
     }
-    // swiftlint:disable:next line_length
-    // functions to test: computeProgressByAveragingOutcomeValues, computeProgressByMedianOutcomeValues, computeProgressByStreakOutcomeValues
-
 }
-
-/*
- 
- gets the outcomeValues of the event, if there is no outcome values then we return an empty array
-  let outcomeValues = event.outcome?.values ?? []
-
-  counts the number of outcomeValues
-  let completedOutcomesValues = Double(outcomeValues.count)
- 
- sums up the outcome values after converting them into a double
- let summedOutcomesValue = outcomeValues
-     .map(accumulableDoubleValue)
-     .reduce(0, +)
- 
- 
- gets target values of an event and sums them up
- let targetValues = event.scheduleEvent.element.targetValues
-
- let summedTargetValue = targetValues
-     .map(accumulableDoubleValue)
-     .reduce(nil) { partialResult, nextTarget -> Double? in
-         return sum(partialResult, nextTarget)
- 
- if there is at least one outcome value, get the average
- var value = 0.0
- if completedOutcomesValues >= 1.0 {
-     value = summedOutcomesValue / completedOutcomesValues
- 
- creates a LinearCareTaskProgress with the calculated average value and summed target value
- let progress = LinearCareTaskProgress(
-     value: value,
-     goal: summedTargetValue
- */


### PR DESCRIPTION
changed the title of OCKEventAggregator.swift to CareTaskProgressStrategy+Math

- [x] removed struct CustomLinearCareTaskProgress
- [x] removed all appearances of CustomLinearCareTaskProgress to LinearCareTaskProgress