### PR TITLE
fix: Build for older versions of Xcode

### DIFF
--- a/Sources/CareKitEssentials/Extensions/CareStoreFetchedResult+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/CareStoreFetchedResult+Hashable.swift
@@ -10,7 +10,7 @@ import CareKit
 import CareKitStore
 import Foundation
 
-extension CareStoreFetchedResult: @retroactive Hashable where Result: Hashable {
+extension CareStoreFetchedResult: Hashable where Result: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(result)

--- a/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Comparable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Comparable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKAnyEvent: @retroactive Comparable {
+extension OCKAnyEvent: Comparable {
 
     public static func < (lhs: OCKAnyEvent, rhs: OCKAnyEvent) -> Bool {
         lhs.scheduleEvent.start <= rhs.scheduleEvent.start &&

--- a/Sources/CareKitEssentials/Extensions/OCKAnyEvent+CustomStringConvertable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKAnyEvent+CustomStringConvertable.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CareKitStore
 
-extension OCKAnyEvent: @retroactive CustomStringConvertible {
+extension OCKAnyEvent: CustomStringConvertible {
 
     public var description: String {
         guard let task = self.task as? OCKTask,

--- a/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Equatable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Equatable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKAnyEvent: @retroactive Equatable {
+extension OCKAnyEvent: Equatable {
     public static func == (
         lhs: OCKAnyEvent,
         rhs: OCKAnyEvent

--- a/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Hashable.swift
@@ -9,7 +9,7 @@
 import CareKitStore
 import Foundation
 
-extension OCKAnyEvent: @retroactive Hashable {
+extension OCKAnyEvent: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(scheduleEvent)

--- a/Sources/CareKitEssentials/Extensions/OCKBiologicalSex+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKBiologicalSex+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKBiologicalSex: @retroactive Hashable {
+extension OCKBiologicalSex: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
 

--- a/Sources/CareKitEssentials/Extensions/OCKNote+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKNote+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKNote: @retroactive Hashable {
+extension OCKNote: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(author)
         hasher.combine(title)

--- a/Sources/CareKitEssentials/Extensions/OCKOutcome+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcome+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKOutcome: @retroactive Hashable {
+extension OCKOutcome: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(values)

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKOutcomeValue: @retroactive Hashable {
+extension OCKOutcomeValue: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(kind)
         hasher.combine(units)

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+Identifiable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+Identifiable.swift
@@ -20,7 +20,7 @@ extension OCKOutcomeValue: Identifiable {
 }
 
 /*
-extension OCKScheduleEvent: @retroactive Hashable {
+extension OCKScheduleEvent: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(start)
         hasher.combine(end)

--- a/Sources/CareKitEssentials/Extensions/OCKSchedule+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKSchedule+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKSchedule: @retroactive Hashable {
+extension OCKSchedule: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(elements)
     }

--- a/Sources/CareKitEssentials/Extensions/OCKScheduleElement+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKScheduleElement+Hashable.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CareKitStore
 
-extension OCKScheduleElement: @retroactive Hashable {
+extension OCKScheduleElement: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(text)
         hasher.combine(duration)
@@ -20,7 +20,7 @@ extension OCKScheduleElement: @retroactive Hashable {
     }
 }
 
-extension OCKScheduleElement.Duration: @retroactive Hashable {
+extension OCKScheduleElement.Duration: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
         case .seconds(let seconds):

--- a/Sources/CareKitEssentials/Extensions/OCKScheduleEvent+Comparable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKScheduleEvent+Comparable.swift
@@ -7,7 +7,7 @@
 
 import CareKitStore
 
-extension OCKScheduleEvent: @retroactive Comparable {
+extension OCKScheduleEvent: Comparable {
     public static func < (lhs: Self, rhs: Self) -> Bool {
         if lhs.start < rhs.start {
             return true

--- a/Sources/CareKitEssentials/Extensions/OCKScheduleEvent+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKScheduleEvent+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKScheduleEvent: @retroactive Hashable {
+extension OCKScheduleEvent: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(start)
         hasher.combine(end)

--- a/Sources/CareKitEssentials/Extensions/OCKSemanticVersion+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKSemanticVersion+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKSemanticVersion: @retroactive Hashable {
+extension OCKSemanticVersion: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(majorVersion)
         hasher.combine(minorVersion)

--- a/Sources/CareKitEssentials/Extensions/OCKStore+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKStore+Hashable.swift
@@ -8,14 +8,14 @@
 
 import CareKitStore
 
-extension OCKStore: @retroactive Hashable {
+extension OCKStore: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(name)
         hasher.combine(securityApplicationGroupIdentifier)
     }
 }
 
-extension OCKCoreDataStoreType: @retroactive Hashable {
+extension OCKCoreDataStoreType: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
 

--- a/Sources/CareKitEssentials/Extensions/OCKTask+Hashable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKTask+Hashable.swift
@@ -8,7 +8,7 @@
 
 import CareKitStore
 
-extension OCKTask: @retroactive Hashable {
+extension OCKTask: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(uuid)


### PR DESCRIPTION
Remove retroactive keyword to build for older versions.

Note that additional warnings will show on respective extensions in Xcode 16+