### PR TITLE
feat: Add methods to convert Result<->OCKOutcomeValue

### DIFF
--- a/CareKitEssentials.xcodeproj/project.pbxproj
+++ b/CareKitEssentials.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		70C422DA2C3B6C7600E6DC51 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 70C422D92C3B6C7600E6DC51 /* Preview Assets.xcassets */; };
 		70C422DF2C3B6C8D00E6DC51 /* CareKitEssentials.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "carekitessentials::CareKitEssentials::Product" /* CareKitEssentials.framework */; };
 		70C422E02C3B6C8D00E6DC51 /* CareKitEssentials.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = "carekitessentials::CareKitEssentials::Product" /* CareKitEssentials.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		70E342102DB02510005124F9 /* OCKOutcomeValue+ResearchKitSwiftUIResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E3420F2DB02507005124F9 /* OCKOutcomeValue+ResearchKitSwiftUIResult.swift */; };
 		70EBE30C2D19FC0F00517D5E /* EventWithContentViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE30B2D19FC0F00517D5E /* EventWithContentViewable.swift */; };
 		70EBE30D2D19FC0F00517D5E /* EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE30A2D19FC0F00517D5E /* EventViewable.swift */; };
 		70EBE3102D19FC2A00517D5E /* EventQueryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE30F2D19FC2A00517D5E /* EventQueryView.swift */; };
@@ -208,6 +209,7 @@
 		70C422D52C3B6C7600E6DC51 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		70C422D72C3B6C7600E6DC51 /* TestHost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestHost.entitlements; sourceTree = "<group>"; };
 		70C422D92C3B6C7600E6DC51 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		70E3420F2DB02507005124F9 /* OCKOutcomeValue+ResearchKitSwiftUIResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcomeValue+ResearchKitSwiftUIResult.swift"; sourceTree = "<group>"; };
 		70EBE30A2D19FC0F00517D5E /* EventViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventViewable.swift; sourceTree = "<group>"; };
 		70EBE30B2D19FC0F00517D5E /* EventWithContentViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventWithContentViewable.swift; sourceTree = "<group>"; };
 		70EBE30E2D19FC2A00517D5E /* EventQueryContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueryContentView.swift; sourceTree = "<group>"; };
@@ -481,8 +483,9 @@
 				OBJ_33 /* OCKOutcome.swift */,
 				70B49A822D0A56910023E5B3 /* OCKOutcome+Hashable.swift */,
 				70B49A842D0A56B70023E5B3 /* OCKOutcomeValue+Hashable.swift */,
-				70721CE32D658EBC00270799 /* OCKOutcomeValue+Sequence.swift */,
 				OBJ_34 /* OCKOutcomeValue+Identifiable.swift */,
+				70E3420F2DB02507005124F9 /* OCKOutcomeValue+ResearchKitSwiftUIResult.swift */,
+				70721CE32D658EBC00270799 /* OCKOutcomeValue+Sequence.swift */,
 				7026DDF02D0CD7DB002EACAA /* OCKSchedule+Hashable.swift */,
 				7026DDEA2D0CD47F002EACAA /* OCKScheduleElement+Hashable.swift */,
 				70BBCB482A12B9B300759A9C /* OCKScheduleEvent+Comparable.swift */,
@@ -757,6 +760,7 @@
 				7026DDF32D0CD7F2002EACAA /* OCKScheduleEvent+Hashable.swift in Sources */,
 				7026DDEB2D0CD489002EACAA /* OCKScheduleElement+Hashable.swift in Sources */,
 				OBJ_740 /* CustomLabelView.swift in Sources */,
+				70E342102DB02510005124F9 /* OCKOutcomeValue+ResearchKitSwiftUIResult.swift in Sources */,
 				7026DDF72D0D2B33002EACAA /* OCKAnyEvent+Equatable.swift in Sources */,
 				OBJ_742 /* DetailsView.swift in Sources */,
 				70EBE3172D19FFE900517D5E /* LabeledValueTaskView+CareStoreFetchedViewable.swift in Sources */,

--- a/Sources/CareKitEssentials/Cards/Shared/ResearchSurveyView/ResearchCareForm.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/ResearchSurveyView/ResearchCareForm.swift
@@ -68,109 +68,18 @@ public struct ResearchCareForm<Content: View>: CareKitEssentialView {
         dismiss()
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     func createOutcomeValuesFromResearchKitResults(
         _ results: ResearchFormResult
     ) -> [OCKOutcomeValue] {
 
-        let outcomeKindPrefix = self.event.task.id
         let multipleOutcomeValues = results.compactMap { result -> [OCKOutcomeValue]? in
-            switch result.answer {
-            case .date(let date):
-                guard let date = date else { return nil }
-
-                var outcomeValue = OCKOutcomeValue(
-                    date
-                )
-                outcomeValue.kind = outcomeKindPrefix
-                return [outcomeValue]
-
-            case .text(let text):
-                guard let text = text else { return nil }
-
-                var outcomeValue = OCKOutcomeValue(
-                    text
-                )
-                outcomeValue.kind = outcomeKindPrefix
-                return [outcomeValue]
-
-            case .numeric(let numeric):
-                guard let numeric = numeric else { return nil }
-
-                var outcomeValue = OCKOutcomeValue(
-                    numeric
-                )
-                outcomeValue.kind = outcomeKindPrefix
-                return [outcomeValue]
-
-            case .weight(let weight):
-                guard let weight = weight else { return nil }
-
-                var outcomeValue = OCKOutcomeValue(
-                    weight
-                )
-                outcomeValue.kind = outcomeKindPrefix
-                return [outcomeValue]
-
-            case .height(let height):
-                guard let height = height else { return nil }
-
-                var outcomeValue = OCKOutcomeValue(
-                    height
-                )
-                outcomeValue.kind = outcomeKindPrefix
-                return [outcomeValue]
-
-            case .multipleChoice(let choices):
-                guard let choices = choices else { return nil }
-
-                let values = choices.compactMap { choice -> OCKOutcomeValue? in
-                    switch choice {
-
-                    case .int(let valueInteger):
-                        var outcomeValue = OCKOutcomeValue(
-                            valueInteger
-                        )
-                        outcomeValue.kind = outcomeKindPrefix
-                        return outcomeValue
-
-                    case .string(let valueString):
-                        var outcomeValue = OCKOutcomeValue(
-                            valueString
-                        )
-                        outcomeValue.kind = outcomeKindPrefix
-                        return outcomeValue
-
-                    case .date(let valueDate):
-                        var outcomeValue = OCKOutcomeValue(
-                            valueDate
-                        )
-                        outcomeValue.kind = outcomeKindPrefix
-                        return outcomeValue
-
-                    @unknown default:
-                        return nil
-                    }
-                }
-                return values
-
-            case .image:
-                let errorMessage = "Image outcomes are not supported yet."
-                Logger.researchCareForm.error("\(errorMessage)")
-                return nil
-
-            case .scale(let scaleValue):
-                guard let scaleValue = scaleValue else { return nil }
-                let scaleIntValue = Int(round(scaleValue))
-                var outcomeValue = OCKOutcomeValue(
-                    scaleIntValue
-                )
-                outcomeValue.kind = outcomeKindPrefix
-                return [outcomeValue]
-
-            @unknown default:
-                return nil
-            }
+			do {
+				let convertedResult = try result.convertToOCKOutcomeValues()
+				return convertedResult
+			} catch {
+				Logger.researchCareForm.error("Cannot convert result to OCKOutcomeValue's: \(error)")
+				return nil
+			}
         }
 
         // Flatten results as they are currently multi-dimentional arrays

--- a/Sources/CareKitEssentials/Extensions/Logger.swift
+++ b/Sources/CareKitEssentials/Extensions/Logger.swift
@@ -39,4 +39,8 @@ extension Logger {
 		subsystem: subsystem,
 		category: "OCKTaskResearchKitSwiftUI"
 	)
+	static let ockOutcomeValueResearchKitResult = Logger(
+		subsystem: subsystem,
+		category: "OCKOutcomeValueResearchKitResult"
+	)
 }

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
@@ -124,7 +124,7 @@ extension ResearchKitSwiftUI.Result {
 			return [outcomeValue]
 
 		@unknown default:
-			throw CareKitEssentialsError.errorString("Reach an unsupported case in convertToOCKOutcomeValue()")
+			throw CareKitEssentialsError.errorString("Reached an unsupported case in convertToOCKOutcomeValue()")
 		}
 	}
 }

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
@@ -8,6 +8,7 @@
 
 #if canImport(ResearchKitSwiftUI)
 import CareKitStore
+import os.log
 import ResearchKitSwiftUI
 
 extension ResearchKitSwiftUI.Result {

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
@@ -7,6 +7,7 @@
 //
 
 #if canImport(ResearchKitSwiftUI)
+import CareKitStore
 import ResearchKitSwiftUI
 
 extension ResearchKitSwiftUI.Result {

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
@@ -1,0 +1,201 @@
+//
+//  OCKOutcomeValue+ResearchKitSwiftUI.swift
+//  CareKitEssentials
+//
+//  Created by Corey Baker on 4/16/25.
+//  Copyright © 2025 Network Reconnaissance Lab. All rights reserved.
+//
+
+#if canImport(ResearchKitSwiftUI)
+import ResearchKitSwiftUI
+
+extension ResearchKitSwiftUI.Result {
+
+	/// Converts an `ResearchKitSwiftUI.Result` to an array of `OCKOutcomeValue`'s.
+	// swiftlint:disable:next cyclomatic_complexity
+	public func convertToOCKOutcomeValues() throws -> [OCKOutcomeValue] {
+
+		switch answer {
+		case .date(let date):
+			guard let date = date else {
+				throw CareKitEssentialsError.errorString("Could not unwrap date")
+			}
+
+			var outcomeValue = OCKOutcomeValue(
+				date
+			)
+			outcomeValue.kind = identifier
+			return [outcomeValue]
+
+		case .text(let text):
+			guard let text = text else {
+				throw CareKitEssentialsError.errorString("Could not unwrap text")
+			}
+
+			var outcomeValue = OCKOutcomeValue(
+				text
+			)
+			outcomeValue.kind = identifier
+			return [outcomeValue]
+
+		case .numeric(let numeric):
+			guard let numeric = numeric else {
+				throw CareKitEssentialsError.errorString("Could not unwrap numeric")
+			}
+
+			var outcomeValue = OCKOutcomeValue(
+				numeric
+			)
+			outcomeValue.kind = identifier
+			return [outcomeValue]
+
+		case .weight(let weight):
+			guard let weight = weight else {
+				CareKitEssentialsError.errorString("Could not unwrap weight")
+			}
+
+			var outcomeValue = OCKOutcomeValue(
+				weight
+			)
+			outcomeValue.kind = identifier
+			return [outcomeValue]
+
+		case .height(let height):
+			guard let height = height else {
+				CareKitEssentialsError.errorString("Could not unwrap height")
+			}
+
+			var outcomeValue = OCKOutcomeValue(
+				height
+			)
+			outcomeValue.kind = identifier
+			return [outcomeValue]
+
+		case .multipleChoice(let choices):
+			guard let choices = choices else {
+				throw CareKitEssentialsError.errorString("Could not unwrap choices")
+			}
+
+			let values = choices.compactMap { choice -> OCKOutcomeValue? in
+				switch choice {
+
+				case .int(let valueInteger):
+					var outcomeValue = OCKOutcomeValue(
+						valueInteger
+					)
+					outcomeValue.kind = identifier
+					return outcomeValue
+
+				case .string(let valueString):
+					var outcomeValue = OCKOutcomeValue(
+						valueString
+					)
+					outcomeValue.kind = identifier
+					return outcomeValue
+
+				case .date(let valueDate):
+					var outcomeValue = OCKOutcomeValue(
+						valueDate
+					)
+					outcomeValue.kind = identifier
+					return outcomeValue
+
+				@unknown default:
+					Logger.ockOutcomeValueResearchKitResult.error("Unsupported choice type.")
+					return nil
+				}
+			}
+			return values
+
+		case .image:
+			// let errorMessage = "Image outcomes are not supported yet."
+			// Logger.researchCareForm.error("\(errorMessage)")
+			throw CareKitEssentialsError.errorString("image is currently not supported")
+
+		case .scale(let scaleValue):
+			guard let scaleValue = scaleValue else {
+				throw CareKitEssentialsError.errorString("Could not unwrap scaleValue")
+			}
+			var outcomeValue = OCKOutcomeValue(
+				scaleValue
+			)
+			outcomeValue.kind = identifier
+			return [outcomeValue]
+
+		@unknown default:
+			throw CareKitEssentialsError.errorString("Reach an unsupported case in convertToOCKOutcomeValue()")
+		}
+	}
+}
+
+extension OCKOutcomeValue {
+
+	/// Converts an `OCKOutcomeValue` to a `ResearchKitSwiftUI.Result`.
+	public func convertToResearchKitResult() throws -> ResearchKitSwiftUI.Result {
+
+		guard let identifier = kind else {
+			throw CareKitEssentialsError.errorString("Could not get the \"identifier\" from \"kind\"")
+		}
+
+		switch type {
+
+		case .integer:
+			guard let integerValue else {
+				throw CareKitEssentialsError.errorString("Could not unwrap integerValue")
+			}
+			let answer = AnswerFormat.numeric(Double(integerValue))
+			let result = ResearchKitSwiftUI.Result(
+				identifier: identifier,
+				answer: answer
+			)
+
+			return result
+
+		case .double:
+			let answer = AnswerFormat.numeric(doubleValue)
+			let result = ResearchKitSwiftUI.Result(
+				identifier: identifier,
+				answer: answer
+			)
+
+			return result
+
+		case .boolean:
+			guard let booleanValue else {
+				throw CareKitEssentialsError.errorString("Could not unwrap booleanValue")
+			}
+			let doubleBoolean: Double = booleanValue ? 1 : 0
+			let answer = AnswerFormat.numeric(doubleBoolean)
+			let result = ResearchKitSwiftUI.Result(
+				identifier: identifier,
+				answer: answer
+			)
+
+			return result
+
+		case .text:
+			let answer = AnswerFormat.text(stringValue)
+			let result = ResearchKitSwiftUI.Result(
+				identifier: identifier,
+				answer: answer
+			)
+
+			return result
+
+		case .binary:
+			throw CareKitEssentialsError.errorString("binary is currently not supported")
+
+		case .date:
+			let answer = AnswerFormat.date(dateValue)
+			let result = ResearchKitSwiftUI.Result(
+				identifier: identifier,
+				answer: answer
+			)
+
+			return result
+
+		}
+	}
+}
+
+#endif

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
@@ -13,7 +13,7 @@ import ResearchKitSwiftUI
 
 extension ResearchKitSwiftUI.Result {
 
-	/// Converts an `ResearchKitSwiftUI.Result` to an array of `OCKOutcomeValue`'s.
+	/// Converts a `ResearchKitSwiftUI.Result` to an array of `OCKOutcomeValue`'s.
 	// swiftlint:disable:next cyclomatic_complexity
 	public func convertToOCKOutcomeValues() throws -> [OCKOutcomeValue] {
 
@@ -132,7 +132,7 @@ extension ResearchKitSwiftUI.Result {
 
 extension OCKOutcomeValue {
 
-	/// Converts an `OCKOutcomeValue` to a `ResearchKitSwiftUI.Result`.
+	/// Converts n `OCKOutcomeValue` to a `ResearchKitSwiftUI.Result`.
 	public func convertToResearchKitResult() throws -> ResearchKitSwiftUI.Result {
 
 		guard let identifier = kind else {

--- a/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKOutcomeValue+ResearchKitSwiftUIResult.swift
@@ -53,7 +53,7 @@ extension ResearchKitSwiftUI.Result {
 
 		case .weight(let weight):
 			guard let weight = weight else {
-				CareKitEssentialsError.errorString("Could not unwrap weight")
+				throw CareKitEssentialsError.errorString("Could not unwrap weight")
 			}
 
 			var outcomeValue = OCKOutcomeValue(
@@ -64,7 +64,7 @@ extension ResearchKitSwiftUI.Result {
 
 		case .height(let height):
 			guard let height = height else {
-				CareKitEssentialsError.errorString("Could not unwrap height")
+				throw CareKitEssentialsError.errorString("Could not unwrap height")
 			}
 
 			var outcomeValue = OCKOutcomeValue(


### PR DESCRIPTION
Adds two methods to assist with converting between CareKit and ResearchKitSwiftUI:

```swift
extension ResearchKitSwiftUI.Result {

	/// Converts an `ResearchKitSwiftUI.Result` to an array of `OCKOutcomeValue`'s.
	public func convertToOCKOutcomeValues() throws -> [OCKOutcomeValue] {...}
}

extension OCKOutcomeValue {

	/// Converts an `OCKOutcomeValue` to a `ResearchKitSwiftUI.Result`.
	public func convertToResearchKitResult() throws -> ResearchKitSwiftUI.Result {...}
}
```