### PR TITLE
feat: Show chart details in Split View when possible

### DIFF
--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CKEConfigurationView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CKEConfigurationView.swift
@@ -19,7 +19,7 @@ struct CKEConfigurationView: View {
 	@State var isShowingMedianMark: Bool = false
 
     var body: some View {
-		VStack(alignment: .leading) {
+		VStack {
 			Section(
 				header: Text(String(localized: "CHART_TYPE"))
 					.font(.subheadline)
@@ -43,7 +43,6 @@ struct CKEConfigurationView: View {
 				Toggle("SHOW_MEDIAN", isOn: $isShowingMedianMark)
 			}
 		}
-		.listStyle(.automatic)
 		.onChange(of: markSelected) { newValue in
 			configurations[configurationId]?.mark = newValue
 		}
@@ -106,9 +105,17 @@ struct CKEConfigurationView_Previews: PreviewProvider {
 
 	static var previews: some View {
 		@State var configurations: [String: CKEDataSeriesConfiguration] = [:]
-		CKEConfigurationView(
-			configurationId: "",
-			configurations: $configurations
-		)
+		List {
+			CKEConfigurationView(
+				configurationId: "",
+				configurations: $configurations
+			)
+			.padding()
+			CKEConfigurationView(
+				configurationId: "",
+				configurations: $configurations
+			)
+		}
+		.listStyle(.automatic)
 	}
 }

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareEssentialChartView.swift
@@ -145,36 +145,38 @@ struct CareEssentialChartView_Previews: PreviewProvider {
 
 		NavigationStack {
 			ScrollView {
-				CareEssentialChartView(
-					title: task.title ?? "",
-					subtitle: "Day",
-					dateInterval: dayDateInterval,
-					period: .day,
-					configurations: [configurationBar]
-				)
-				CareEssentialChartView(
-					title: task.title ?? "",
-					subtitle: "Week",
-					dateInterval: weekDateInterval,
-					period: .weekday,
-					configurations: [configurationBar]
-				)
-				CareEssentialChartView(
-					title: task.title ?? "",
-					subtitle: "Month",
-					dateInterval: monthDateInterval,
-					period: .month,
-					configurations: [configurationBar]
-				)
-				CareEssentialChartView(
-					title: task.title ?? "",
-					subtitle: "Year",
-					dateInterval: yearDateInterval,
-					period: .year,
-					configurations: [configurationBar]
-				)
+				VStack {
+					CareEssentialChartView(
+						title: task.title ?? "",
+						subtitle: "Day",
+						dateInterval: dayDateInterval,
+						period: .day,
+						configurations: [configurationBar]
+					)
+					CareEssentialChartView(
+						title: task.title ?? "",
+						subtitle: "Week",
+						dateInterval: weekDateInterval,
+						period: .weekday,
+						configurations: [configurationBar]
+					)
+					CareEssentialChartView(
+						title: task.title ?? "",
+						subtitle: "Month",
+						dateInterval: monthDateInterval,
+						period: .month,
+						configurations: [configurationBar]
+					)
+					CareEssentialChartView(
+						title: task.title ?? "",
+						subtitle: "Year",
+						dateInterval: yearDateInterval,
+						period: .year,
+						configurations: [configurationBar]
+					)
+				}
+				.padding()
 			}
-			.padding()
 		}
 		.environment(\.careStore, previewStore)
 		.environment(\.careKitStyle, OCKStyle())

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareEssentialChartView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 NetReconLab. All rights reserved.
 //
 
+import CareKitUI
 import Foundation
 import os.log
 import SwiftUI
@@ -142,8 +143,8 @@ struct CareEssentialChartView_Previews: PreviewProvider {
 			return interval
 		}
 
-		ScrollView {
-			VStack {
+		NavigationStack {
+			ScrollView {
 				CareEssentialChartView(
 					title: task.title ?? "",
 					subtitle: "Day",
@@ -176,5 +177,6 @@ struct CareEssentialChartView_Previews: PreviewProvider {
 			.padding()
 		}
 		.environment(\.careStore, previewStore)
+		.environment(\.careKitStyle, OCKStyle())
 	}
 }

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
@@ -56,7 +56,6 @@ struct CareKitEssentialChartBodyView: View {
 			// to the method below.
 			makeAllAdditionalMarks(series: data)
 		}
-		.chartXScale(domain: dateInterval.start...dateInterval.end, type: .date)
 		.chartXAxis {
 			AxisMarks { _ in
 				if showGridLines {
@@ -92,6 +91,7 @@ struct CareKitEssentialChartBodyView: View {
 				if isAllowingHorizontalScroll {
 					chart
 						.chartScrollableAxes(.horizontal)
+						// .chartXVisibleDomain(length: )
 						.chartXSelection(value: $selectedDate)
 				} else {
 					chart.chartXSelection(value: $selectedDate)
@@ -123,11 +123,6 @@ struct CareKitEssentialChartBodyView: View {
 					Text(markerLocalizedString("VALUE_DISPLAY", value: selected.1))
 				}
 				.font(.caption)
-			} else if let selectedDate {
-				VStack {
-					dateFormatted(date: selectedDate, series: series)
-				}
-				.font(.caption)
 			}
 		}
 	}
@@ -155,6 +150,15 @@ struct CareKitEssentialChartBodyView: View {
 		)
 	}
 
+	func selectedDateValue(series: CKEDataSeries) -> (Date, Double)? {
+		guard let selectedDate,
+			  let value = series.selectedDataValue(for: selectedDate) else {
+			return nil
+		}
+
+		return (selectedDate, value)
+	}
+
 	// MARK: Private Helpers
 	@ViewBuilder
 	private func dateFormatted(date: Date, series: CKEDataSeries) -> some View {
@@ -163,15 +167,6 @@ struct CareKitEssentialChartBodyView: View {
 		} else {
 			Text(date.formatted(.dateTime.month().day().hour()))
 		}
-	}
-
-	private func selectedDateValue(series: CKEDataSeries) -> (Date, Double)? {
-		guard let selectedDate,
-			  let value = series.selectedDataValue(for: selectedDate) else {
-			return nil
-		}
-
-		return (selectedDate, value)
 	}
 
 	private func updateLegendColors() {

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
@@ -117,12 +117,41 @@ struct CareKitEssentialChartBodyView: View {
 	@ViewBuilder
 	func selectionPopover(series: CKEDataSeries) -> some View {
 		if series.showMarkWhenHighlighted {
-			if let selected = selectedDateValue(series: series) {
+			if let selectedDate,
+				let selected = selectedDateValue(series: series) {
 				VStack {
+					let point = series.selectedDataPoint(for: selectedDate)
+					let yUnit = point?.yUnit ?? ""
+					if let yAxisLabel = series.yAxisLabel {
+						Text(yAxisLabel.uppercased())
+							.font(.caption)
+					}
+					HStack {
+						Text(selected.1.formatted())
+							.font(.largeTitle)
+						Text(yUnit)
+							.font(.caption)
+					}
 					dateFormatted(date: selected.0, series: series)
-					Text(markerLocalizedString("VALUE_DISPLAY", value: selected.1))
+						.font(.caption)
 				}
-				.font(.caption)
+			} else if let selectedDate {
+				VStack {
+					let point = series.selectedDataPoint(for: selectedDate)
+					let yUnit = point?.yUnit ?? ""
+					if let yAxisLabel = series.yAxisLabel {
+						Text(yAxisLabel.uppercased())
+							.font(.caption)
+					}
+					HStack {
+						Text("0")
+							.font(.largeTitle)
+						Text(yUnit)
+							.font(.caption)
+					}
+					dateFormatted(date: selectedDate, series: series)
+						.font(.caption)
+				}
 			}
 		}
 	}

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
@@ -14,6 +14,7 @@ struct CareKitEssentialChartBodyView: View {
 
 	@Environment(\.careKitStyle) private var style
 	let dataSeries: [CKEDataSeries]
+	let dateInterval: DateInterval
 	@State var showGridLines: Bool = false
 	@State var isAllowingHorizontalScroll: Bool = false
 	@State var legendColors = [String: LinearGradient]()
@@ -55,6 +56,7 @@ struct CareKitEssentialChartBodyView: View {
 			// to the method below.
 			makeAllAdditionalMarks(series: data)
 		}
+		.chartXScale(domain: dateInterval.start...dateInterval.end, type: .date)
 		.chartXAxis {
 			AxisMarks { _ in
 				if showGridLines {

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartBodyView.swift
@@ -29,6 +29,7 @@ struct CareKitEssentialChartBodyView: View {
 					xValueUnit: point.xUnit,
 					yLabel: data.yLabel,
 					yValue: point.y,
+					point: point,
 					width: data.width,
 					height: data.height,
 					stacking: data.stackingMethod

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
@@ -29,41 +29,24 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 	var body: some View {
 		VStack {
 			let dataSeries = graphDataForEvents(events)
-			NavigationLink(
-				destination: {
-					let dataSeries = graphDataForEvents(events)
-					CareKitEssentialChartBodyView(
-						dataSeries: dataSeries,
-						dateInterval: dateInterval,
-						showGridLines: true
-					)
-					#if !os(watchOS)
-					.aspectRatio(
-						CGSize(width: 16, height: 9),
-						contentMode: .fit
-					)
-					#endif
-					.padding()
-				}
-			) {
-				CareKitEssentialChartBodyView(
-					dataSeries: dataSeries,
-					dateInterval: dateInterval,
-					showGridLines: true
-				)
-				.onAppear {
-					updateQuery()
-				}
-				.onChange(of: dateInterval) { _ in
-					updateQuery()
-				}
-				.onChange(of: configurations) { _ in
-					updateQuery()
-				}
-				.onReceive(events.publisher) { _ in
-					updateQuery()
-				}
+			CareKitEssentialChartBodyView(
+				dataSeries: dataSeries,
+				dateInterval: dateInterval,
+				showGridLines: true
+			)
+			.onAppear {
+				updateQuery()
 			}
+			.onChange(of: dateInterval) { _ in
+				updateQuery()
+			}
+			.onChange(of: configurations) { _ in
+				updateQuery()
+			}
+			.onReceive(events.publisher) { _ in
+				updateQuery()
+			}
+
 			#if os(watchOS) || os(visionOS)
 			.buttonStyle(PlainButtonStyle())
 			#endif
@@ -106,6 +89,17 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 				}
 			}
 			.listStyle(.automatic)
+		}
+		.toolbar {
+			#if !os(watchOS)
+			ToolbarItem(placement: .automatic) {
+				fullScreenView
+			}
+			#else
+			ToolbarItem(placement: .topBarTrailing) {
+				fullScreenView
+			}
+			#endif
 		}
 	}
 
@@ -153,6 +147,28 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 		#else
 		.pickerStyle(.automatic)
 		#endif
+	}
+
+	var fullScreenView: some View {
+		NavigationLink(
+			destination: {
+				let dataSeries = graphDataForEvents(events)
+				CareKitEssentialChartBodyView(
+					dataSeries: dataSeries,
+					dateInterval: dateInterval,
+					showGridLines: true
+				)
+				#if !os(watchOS)
+				.aspectRatio(
+					CGSize(width: 16, height: 9),
+					contentMode: .fit
+				)
+				#endif
+				.padding()
+			}
+		) {
+			Image(systemName: "inset.filled.rectangle.and.person.filled")
+		}
 	}
 
 	private func updateQuery() {

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
@@ -33,6 +33,7 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 			let dataSeries = graphDataForEvents(events)
 			CareKitEssentialChartBodyView(
 				dataSeries: dataSeries,
+				dateInterval: dateInterval,
 				showGridLines: true
 			)
 			#if !os(watchOS) && !os(visionOS)
@@ -110,6 +111,7 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 					let dataSeries = graphDataForEvents(events)
 					CareKitEssentialChartBodyView(
 						dataSeries: dataSeries,
+						dateInterval: dateInterval,
 						showGridLines: true
 					)
 					#if !os(watchOS)

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
@@ -25,38 +25,55 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 	@State var period: PeriodComponent
 	@State var configurations: [String: CKEDataSeriesConfiguration]
 	let orderedConfigurations: [CKEDataSeriesConfiguration]
-	@State var isShowingLargeChart: Bool = false
 
 	var body: some View {
 		VStack {
 
 			let dataSeries = graphDataForEvents(events)
-			CareKitEssentialChartBodyView(
-				dataSeries: dataSeries,
-				dateInterval: dateInterval,
-				showGridLines: true
-			)
-			#if !os(watchOS) && !os(visionOS)
-			.aspectRatio(
-				CGSize(width: 4, height: 3),
-				contentMode: .fit
-			)
+			NavigationLink(
+				destination: {
+					let dataSeries = graphDataForEvents(events)
+					CareKitEssentialChartBodyView(
+						dataSeries: dataSeries,
+						dateInterval: dateInterval,
+						showGridLines: true
+					)
+					#if !os(watchOS)
+					.aspectRatio(
+						CGSize(width: 16, height: 9),
+						contentMode: .fit
+					)
+					#endif
+					.padding()
+				}
+			) {
+				CareKitEssentialChartBodyView(
+					dataSeries: dataSeries,
+					dateInterval: dateInterval,
+					showGridLines: true
+				)
+#if !os(watchOS) && !os(visionOS) && !os(macOS)
+				.aspectRatio(
+					CGSize(width: 4, height: 3),
+					contentMode: .fit
+				)
+#endif
+				.onAppear {
+					updateQuery()
+				}
+				.onChange(of: dateInterval) { _ in
+					updateQuery()
+				}
+				.onChange(of: configurations) { _ in
+					updateQuery()
+				}
+				.onReceive(events.publisher) { _ in
+					updateQuery()
+				}
+			}
+			#if os(watchOS) || os(visionOS)
+			.buttonStyle(PlainButtonStyle())
 			#endif
-			.onAppear {
-				updateQuery()
-			}
-			.onChange(of: dateInterval) { _ in
-				updateQuery()
-			}
-			.onChange(of: configurations) { _ in
-				updateQuery()
-			}
-			.onReceive(events.publisher) { _ in
-				updateQuery()
-			}
-			.onTapGesture {
-				isShowingLargeChart.toggle()
-			}
 
 			Divider()
 				.padding()
@@ -100,27 +117,6 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 						Divider()
 							.padding()
 					}
-				}
-			}
-		}
-		.sheet(isPresented: $isShowingLargeChart) {
-			DismissableView(
-				title: title
-			) {
-				VStack {
-					let dataSeries = graphDataForEvents(events)
-					CareKitEssentialChartBodyView(
-						dataSeries: dataSeries,
-						dateInterval: dateInterval,
-						showGridLines: true
-					)
-					#if !os(watchOS)
-					.aspectRatio(
-						CGSize(width: 16, height: 9),
-						contentMode: .fit
-					)
-					#endif
-					.padding()
 				}
 			}
 		}

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
@@ -28,7 +28,6 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 
 	var body: some View {
 		VStack {
-
 			let dataSeries = graphDataForEvents(events)
 			NavigationLink(
 				destination: {
@@ -52,12 +51,6 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 					dateInterval: dateInterval,
 					showGridLines: true
 				)
-#if !os(watchOS) && !os(visionOS) && !os(macOS)
-				.aspectRatio(
-					CGSize(width: 4, height: 3),
-					contentMode: .fit
-				)
-#endif
 				.onAppear {
 					updateQuery()
 				}
@@ -75,10 +68,8 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 			.buttonStyle(PlainButtonStyle())
 			#endif
 
-			Divider()
-				.padding()
+			List {
 
-			ScrollView {
 				VStack(alignment: .leading) {
 					Section(
 						header: Text("PERIOD")
@@ -94,31 +85,27 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 
 				}
 
-				VStack(alignment: .center) {
-					Divider()
+				ForEach(orderedConfigurations) { configuration in
+					let configurationId = configuration.id
+					let currentConfiguration = configurations[configurationId] ?? configuration
 
-					ForEach(orderedConfigurations) { configuration in
-						let configurationId = configuration.id
-						let currentConfiguration = configurations[configurationId] ?? configuration
-
-						Section(
-							header: Text(currentConfiguration.legendTitle)
-						) {
-							CKEConfigurationView(
-								configurationId: configurationId,
-								configurations: $configurations,
-								markSelected: currentConfiguration.mark,
-								dataStrategySelected: currentConfiguration.dataStrategy,
-								isShowingMarkHighlighted: currentConfiguration.showMarkWhenHighlighted,
-								isShowingMeanMark: currentConfiguration.showMeanMark,
-								isShowingMedianMark: currentConfiguration.showMedianMark
-							)
-						}
-						Divider()
-							.padding()
+					Section(
+						header: Text(currentConfiguration.legendTitle)
+					) {
+						CKEConfigurationView(
+							configurationId: configurationId,
+							configurations: $configurations,
+							markSelected: currentConfiguration.mark,
+							dataStrategySelected: currentConfiguration.dataStrategy,
+							isShowingMarkHighlighted: currentConfiguration.showMarkWhenHighlighted,
+							isShowingMeanMark: currentConfiguration.showMeanMark,
+							isShowingMedianMark: currentConfiguration.showMedianMark
+						)
 					}
+
 				}
 			}
+			.listStyle(.automatic)
 		}
 	}
 
@@ -207,22 +194,20 @@ struct CareKitEssentialChartDetailView_Previews: PreviewProvider {
 		}
 
 		NavigationStack {
-			VStack {
-				CareKitEssentialChartDetailView(
-					title: task.title ?? "",
-					subtitle: "Week",
-					dateInterval: weekDateInterval,
-					period: .week,
-					configurations: [
-						configurationBar.id: configurationBar,
-						configurationLine.id: configurationLine
-					],
-					orderedConfigurations: [
-						configurationBar,
-						configurationLine
-					]
-				)
-			}
+			CareKitEssentialChartDetailView(
+				title: task.title ?? "",
+				subtitle: "Week",
+				dateInterval: weekDateInterval,
+				period: .week,
+				configurations: [
+					configurationBar.id: configurationBar,
+					configurationLine.id: configurationLine
+				],
+				orderedConfigurations: [
+					configurationBar,
+					configurationLine
+				]
+			)
 			.padding()
 		}
 		.environment(\.careStore, previewStore)

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
@@ -34,6 +34,7 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 				dateInterval: dateInterval,
 				showGridLines: true
 			)
+			.padding(.horizontal)
 			.onAppear {
 				updateQuery()
 			}

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartDetailView.swift
@@ -61,7 +61,6 @@ struct CareKitEssentialChartDetailView: CareKitEssentialChartable {
 			}
 		) {
 			chartView
-				.padding(.horizontal)
 				.onAppear {
 					updateQuery()
 				}

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
@@ -48,68 +48,59 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 	let orderedConfigurations: [CKEDataSeriesConfiguration]
 
 	public var body: some View {
-		// NavigationStack {
-			CardView {
-				VStack(alignment: .leading) {
-					HStack {
-						CareKitEssentialChartHeaderView(
-							title: title,
-							subtitle: subtitle
-						)
-						Spacer()
-						if showDetailsViewOnTap {
-							NavigationLink(
-								destination: {
-									CareKitEssentialChartDetailView(
-										title: title,
-										subtitle: subtitle,
-										dateInterval: dateInterval,
-										period: period,
-										configurations: configurations,
-										orderedConfigurations: orderedConfigurations
-									)
-									.padding()
-								}
-							) {
-								Image(systemName: "chevron.right")
-									.imageScale(.small)
-#if os(iOS) || os(visionOS)
-									.foregroundColor(Color(style.color.secondaryLabel))
-#else
-									.foregroundColor(Color.secondary)
-#endif
+		CardView {
+			VStack(alignment: .leading) {
+				HStack {
+					CareKitEssentialChartHeaderView(
+						title: title,
+						subtitle: subtitle
+					)
+					Spacer()
+					if showDetailsViewOnTap {
+						NavigationLink(
+							destination: {
+								CareKitEssentialChartDetailView(
+									title: title,
+									subtitle: subtitle,
+									dateInterval: dateInterval,
+									period: period,
+									configurations: configurations,
+									orderedConfigurations: orderedConfigurations
+								)
 							}
-							#if os(watchOS)
-							.buttonStyle(.borderless)
-							#endif
-						}
-					}
-					.padding(.bottom)
-
-					let dataSeries = graphDataForEvents(events)
-					CareKitEssentialChartBodyView(
-						dataSeries: dataSeries,
-						dateInterval: dateInterval
-					)
-#if !os(watchOS) && !os(visionOS)
-					.aspectRatio(
-						CGSize(width: 4, height: 3),
-						contentMode: .fit
-					)
+						) {
+							Image(systemName: "chevron.right")
+								.imageScale(.small)
+#if os(iOS) || os(visionOS)
+								.foregroundColor(Color(style.color.secondaryLabel))
+#else
+								.foregroundColor(Color.secondary)
 #endif
-					.onAppear {
-						updateQuery()
-					}
-					.onChange(of: dateInterval) { _ in
-						updateQuery()
-					}
-					.onChange(of: configurations) { _ in
-						updateQuery()
+						}
+						#if os(watchOS)
+						.buttonStyle(.borderless)
+						#endif
 					}
 				}
-				.padding(isCardEnabled ? [.all] : [])
+				.padding(.bottom)
+
+				let dataSeries = graphDataForEvents(events)
+				CareKitEssentialChartBodyView(
+					dataSeries: dataSeries,
+					dateInterval: dateInterval
+				)
+				.onAppear {
+					updateQuery()
+				}
+				.onChange(of: dateInterval) { _ in
+					updateQuery()
+				}
+				.onChange(of: configurations) { _ in
+					updateQuery()
+				}
 			}
-		// }
+			.padding(isCardEnabled ? [.all] : [])
+		}
 	}
 
 	static func query(taskIDs: [String]? = nil) -> OCKEventQuery {
@@ -200,8 +191,8 @@ struct CareKitEssentialChartView_Previews: PreviewProvider {
 					period: $period,
 					configurations: configurations
 				)
+				.padding()
 			}
-			.padding()
 		}
 		.padding()
 		.environment(\.careStore, previewStore)

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
@@ -36,6 +36,7 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 
 	let title: String
 	let subtitle: String
+	let showDetailsViewOnTap: Bool
 	@Binding var dateInterval: DateInterval
 	@Binding var period: PeriodComponent
 	var configurations: [String: CKEDataSeriesConfiguration]
@@ -50,13 +51,15 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 						subtitle: subtitle
 					)
 					Spacer()
-					Image(systemName: "chevron.right")
-						.imageScale(.small)
-					#if os(iOS) || os(visionOS)
-						.foregroundColor(Color(style.color.secondaryLabel))
-					#else
-						.foregroundColor(Color.secondary)
-					#endif
+					if showDetailsViewOnTap {
+						Image(systemName: "chevron.right")
+							.imageScale(.small)
+							#if os(iOS) || os(visionOS)
+							.foregroundColor(Color(style.color.secondaryLabel))
+							#else
+							.foregroundColor(Color.secondary)
+							#endif
+					}
 				}
 				.padding(.bottom)
 				.onTapGesture {
@@ -85,19 +88,21 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 			}
 			.padding(isCardEnabled ? [.all] : [])
 		}
-		.sheet(isPresented: $isShowingDetail) {
-			DismissableView(
-				title: title
-			) {
-				CareKitEssentialChartDetailView(
-					title: title,
-					subtitle: subtitle,
-					dateInterval: dateInterval,
-					period: period,
-					configurations: configurations,
-					orderedConfigurations: orderedConfigurations
-				)
-				.padding()
+		.if(showDetailsViewOnTap) { view in
+			view.sheet(isPresented: $isShowingDetail) {
+				DismissableView(
+					title: title
+				) {
+					CareKitEssentialChartDetailView(
+						title: title,
+						subtitle: subtitle,
+						dateInterval: dateInterval,
+						period: period,
+						configurations: configurations,
+						orderedConfigurations: orderedConfigurations
+					)
+					.padding()
+				}
 			}
 		}
 	}
@@ -112,6 +117,9 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 	/// Create an instance of chart for displaying CareKit data.
 	/// - title: The title for the chart.
 	/// - subtitle: The subtitle for the chart.
+	/// - showDetailsViewOnTap: Allow showing the details
+	/// view when the header is tapped. Set to `false` to
+	/// disable the details view. This defaults to `true`.
 	/// - dateInterval: The date interval of data to display
 	/// - period: The frequency at which data should be combined.
 	/// - configurations: A configuration object that specifies
@@ -120,12 +128,14 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 	public init(
 		title: String,
 		subtitle: String,
+		showDetailsViewOnTap: Bool = true,
 		dateInterval: Binding<DateInterval>,
 		period: Binding<PeriodComponent>,
 		configurations: [CKEDataSeriesConfiguration]
 	) {
 		self.title = title
 		self.subtitle = subtitle
+		self.showDetailsViewOnTap = showDetailsViewOnTap
 		self.orderedConfigurations = configurations
 		self.configurations = configurations.reduce(
 			into: [String: CKEDataSeriesConfiguration]()

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
@@ -61,6 +61,7 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 									configurations: configurations,
 									orderedConfigurations: orderedConfigurations
 								)
+								.padding()
 							}
 						) {
 							Image(systemName: "chevron.right")

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
@@ -13,11 +13,6 @@ import Foundation
 import os.log
 import SwiftUI
 
-enum ChartViewPath {
-	case details
-	case fullscreen
-}
-
 /// Displays a SwiftUI Chart above an axis. The initializer takes an an array of
 /// `CKEDataSeriesConfiguration`'s which each support
 /// `CKEDataSeries.MarkType` that allows you to overlay from several
@@ -37,7 +32,6 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 	@Environment(\.isCardEnabled) private var isCardEnabled
 	@Environment(\.careKitStyle) private var style
 	@CareStoreFetchRequest(query: query()) private var events
-	@State private var path = [ChartViewPath]()
 
 	let title: String
 	let subtitle: String

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
@@ -68,7 +68,8 @@ public struct CareKitEssentialChartView: CareKitEssentialChartable {
 
 				let dataSeries = graphDataForEvents(events)
 				CareKitEssentialChartBodyView(
-					dataSeries: dataSeries
+					dataSeries: dataSeries,
+					dateInterval: dateInterval
 				)
 				#if !os(watchOS) && !os(visionOS)
 				.aspectRatio(

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
@@ -179,6 +179,7 @@ struct CareKitEssentialChartView_Previews: PreviewProvider {
 				taskID: task.id,
 				mark: .bar,
 				legendTitle: "Bar",
+				yAxisLabel: "Total",
 				showMarkWhenHighlighted: true,
 				showMeanMark: true,
 				color: .red,

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
@@ -254,7 +254,11 @@ public struct CKEDataSeries: Identifiable, Hashable {
 
 		let foundDataPoint = dataPoints.first(where: { range.contains($0.x) })
 
-		return foundDataPoint?.y
+		guard let valueAtPoint = foundDataPoint?.y else {
+			return nil
+		}
+		let realValue = valueAtPoint > 0 ? valueAtPoint : nil
+		return realValue
 	}
 
     /// Creates a new data series that can be passed to a chart to be plotted. The series will be plotted in a single

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
@@ -150,6 +150,8 @@ public struct CKEDataSeries: Identifiable, Hashable {
 	public var showMarkWhenHighlighted: Bool = false
 	public var showMeanMark: Bool = false
 	public var showMedianMark: Bool = false
+	public var xAxisLabel: String?
+	public var yAxisLabel: String?
 	public var xLabel: String = String(localized: "DATE")
 	public var yLabel: String = String(localized: "VALUE")
 	public var yEndLabel: String?
@@ -238,7 +240,7 @@ public struct CKEDataSeries: Identifiable, Hashable {
 		}
 	}
 
-	func selectedDataValue(for date: Date) -> Double? {
+	func selectedDataPoint(for date: Date) -> CKEPoint? {
 		guard let component = dataPoints.first?.xUnit else {
 			return nil
 		}
@@ -254,9 +256,14 @@ public struct CKEDataSeries: Identifiable, Hashable {
 
 		let foundDataPoint = dataPoints.first(where: { range.contains($0.x) })
 
-		guard let valueAtPoint = foundDataPoint?.y else {
+		return foundDataPoint
+	}
+
+	func selectedDataValue(for date: Date) -> Double? {
+		guard let foundDataPoint = selectedDataPoint(for: date) else {
 			return nil
 		}
+		let valueAtPoint = foundDataPoint.y
 		let realValue = valueAtPoint > 0 ? valueAtPoint : nil
 		return realValue
 	}
@@ -324,6 +331,8 @@ public struct CKEDataSeries: Identifiable, Hashable {
 		showMarkWhenHighlighted: Bool = false,
 		showMeanMark: Bool = false,
 		showMedianMark: Bool = false,
+		xAxisLabel: String? = nil,
+		yAxisLabel: String? = nil,
         color: Color,
         gradientStartColor: Color? = nil,
         width: MarkDimension = .automatic,
@@ -339,6 +348,8 @@ public struct CKEDataSeries: Identifiable, Hashable {
 		self.showMarkWhenHighlighted = showMarkWhenHighlighted
 		self.showMeanMark = showMeanMark
 		self.showMedianMark = showMedianMark
+		self.xAxisLabel = xAxisLabel
+		self.yAxisLabel = yAxisLabel
         self.color = color
         self.gradientStartColor = gradientStartColor
         self.stackingMethod = stackingMethod
@@ -359,6 +370,8 @@ public struct CKEDataSeries: Identifiable, Hashable {
 			showMarkWhenHighlighted: configuration.showMarkWhenHighlighted,
 			showMeanMark: configuration.showMeanMark,
 			showMedianMark: configuration.showMedianMark,
+			xAxisLabel: configuration.xAxisLabel,
+			yAxisLabel: configuration.yAxisLabel,
 			color: configuration.color,
 			gradientStartColor: configuration.gradientStartColor,
 			width: configuration.width,
@@ -396,6 +409,8 @@ public struct CKEDataSeries: Identifiable, Hashable {
         accessibilityValues: [String]? = nil,
         title: String,
 		summary: String? = nil,
+		xAxisLabel: String? = nil,
+		yAxisLabel: String? = nil,
         color: Color,
         width: MarkDimension = .automatic,
         height: MarkDimension = .automatic,
@@ -433,6 +448,8 @@ public struct CKEDataSeries: Identifiable, Hashable {
         }
         self.title = title
 		self.summary = summary
+		self.xAxisLabel = xAxisLabel
+		self.yAxisLabel = yAxisLabel
         self.color = color
         self.stackingMethod = stackingMethod
         self.width = width

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
@@ -103,38 +103,38 @@ public struct CKEDataSeries: Identifiable, Hashable {
             height: MarkDimension,
             stacking: MarkStackingMethod
         ) -> some ChartContent where ValueY: Plottable {
-            switch self {
-            case .area:
-                AreaMark(
+			switch self {
+			case .area:
+				AreaMark(
 					x: .value(xLabel, xValue, unit: xValueUnit),
-                    y: .value(yLabel, yValue),
-                    stacking: stacking
-                )
-            case .bar:
-                BarMark(
-                    x: .value(xLabel, xValue, unit: xValueUnit),
-                    y: .value(yLabel, yValue),
-                    width: width,
-                    height: height,
-                    stacking: stacking
-                )
-            case .line:
-                LineMark(
-                    x: .value(xLabel, xValue, unit: xValueUnit),
-                    y: .value(yLabel, yValue)
-                )
-            case .point:
-                PointMark(
-                    x: .value(xLabel, xValue, unit: xValueUnit),
-                    y: .value(yLabel, yValue)
+					y: .value(yLabel, yValue),
+					stacking: stacking
 				)
-            case .rectangle:
-                RectangleMark(
-                    x: .value(xLabel, xValue, unit: xValueUnit),
-                    y: .value(yLabel, yValue),
-                    width: width,
-                    height: height
-                )
+			case .bar:
+				BarMark(
+					x: .value(xLabel, xValue, unit: xValueUnit),
+					y: .value(yLabel, yValue),
+					width: width,
+					height: height,
+					stacking: stacking
+				)
+			case .line:
+				LineMark(
+					x: .value(xLabel, xValue, unit: xValueUnit),
+					y: .value(yLabel, yValue)
+				)
+			case .point:
+				PointMark(
+					x: .value(xLabel, xValue, unit: xValueUnit),
+					y: .value(yLabel, yValue)
+				)
+			case .rectangle:
+				RectangleMark(
+					x: .value(xLabel, xValue, unit: xValueUnit),
+					y: .value(yLabel, yValue),
+					width: width,
+					height: height
+				)
 			case .scatter:
 				ForEach(0..<point.originalValues.count, id: \.self) { index in
 					PointMark(
@@ -143,7 +143,7 @@ public struct CKEDataSeries: Identifiable, Hashable {
 					)
 					.opacity(0.3)
 				}
-            }
+			}
         }
     }
 

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
@@ -445,14 +445,16 @@ public struct CKEDataSeries: Identifiable, Hashable {
 					x: date,
 					y: value,
 					period: period,
-					originalValues: values
+					originalValues: values,
+					originalOutcomeValues: []
 				)
 			} else {
 				return CKEPoint(
 					x: date,
 					y: value,
 					period: .week,
-					originalValues: values
+					originalValues: values,
+					originalOutcomeValues: []
 				)
 			}
         }
@@ -519,14 +521,16 @@ public struct CKEDataSeries: Identifiable, Hashable {
 					x: date,
 					y: value,
 					period: period,
-					originalValues: values
+					originalValues: values,
+					originalOutcomeValues: []
 				)
 			} else {
 				return CKEPoint(
 					x: date,
 					y: value,
 					period: .week,
-					originalValues: values
+					originalValues: values,
+					originalOutcomeValues: []
 				)
 			}
 		}

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeries.swift
@@ -89,6 +89,7 @@ public struct CKEDataSeries: Identifiable, Hashable {
         case line
         case point
         case rectangle
+		case scatter
 
         @ChartContentBuilder
         func chartContent<ValueY>( // swiftlint:disable:this function_parameter_count
@@ -97,6 +98,7 @@ public struct CKEDataSeries: Identifiable, Hashable {
 			xValueUnit: Calendar.Component,
             yLabel: String,
             yValue: ValueY,
+			point: CKEPoint,
             width: MarkDimension,
             height: MarkDimension,
             stacking: MarkStackingMethod
@@ -133,6 +135,14 @@ public struct CKEDataSeries: Identifiable, Hashable {
                     width: width,
                     height: height
                 )
+			case .scatter:
+				ForEach(0..<point.originalValues.count, id: \.self) { index in
+					PointMark(
+						x: .value(xLabel, point.x, unit: point.xUnit),
+						y: .value(yLabel, point.originalValues[index])
+					)
+					.opacity(0.3)
+				}
             }
         }
     }

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeriesConfiguration.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeriesConfiguration.swift
@@ -41,6 +41,9 @@ public struct CKEDataSeriesConfiguration: Identifiable, Hashable {
     public var legendTitle: String
 
 	/// The label to use for the yAxis.
+	public var xAxisLabel: String?
+
+	/// The label to use for the yAxis.
 	public var yAxisLabel: String?
 
 	public var showMarkWhenHighlighted: Bool = false
@@ -102,6 +105,7 @@ public struct CKEDataSeriesConfiguration: Identifiable, Hashable {
 		kind: String? = nil,
         mark: CKEDataSeries.MarkType,
         legendTitle: String,
+		xAxisLabel: String? = nil,
 		yAxisLabel: String? = nil,
 		showMarkWhenHighlighted: Bool = false,
 		showMeanMark: Bool = false,
@@ -145,6 +149,7 @@ extension CKEDataSeriesConfiguration {
 		&& lhs.taskID == rhs.taskID
 		&& lhs.kind == rhs.kind
 		&& lhs.legendTitle == rhs.legendTitle
+		&& lhs.xAxisLabel == rhs.xAxisLabel
 		&& lhs.yAxisLabel == rhs.yAxisLabel
 		&& lhs.showMarkWhenHighlighted == rhs.showMarkWhenHighlighted
 		&& lhs.showMedianMark == rhs.showMedianMark
@@ -160,6 +165,7 @@ extension CKEDataSeriesConfiguration {
 		hasher.combine(taskID)
 		hasher.combine(kind)
 		hasher.combine(legendTitle)
+		hasher.combine(xAxisLabel)
 		hasher.combine(yAxisLabel)
 		hasher.combine(showMarkWhenHighlighted)
 		hasher.combine(showMedianMark)

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEPoint.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEPoint.swift
@@ -19,5 +19,6 @@ struct CKEPoint: Hashable, Identifiable {
 	var yUnit: String?
 	var period: PeriodComponent
 	var originalValues: [Double]
+	var originalOutcomeValues: [OCKOutcomeValue]
     var accessibilityValue: String?
 }

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Progress/TemporalProgress.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Progress/TemporalProgress.swift
@@ -6,11 +6,13 @@
 //  Copyright © 2024 NetReconLab. All rights reserved.
 //
 
+import CareKitStore
 import Foundation
 
 struct CombinedProgress<Progress> {
 	var value: Progress
 	var originalValues: [Progress]
+	var originalOutcomeValues: [OCKOutcomeValue]
 	var unit: String?
 	var date: Date
 	var period: PeriodComponent
@@ -19,6 +21,7 @@ struct CombinedProgress<Progress> {
 struct TemporalProgress<Progress> {
     var values: [Progress]
 	var units: [String]?
+	var originalOutcomeValues: [OCKOutcomeValue]
     var date: Date
 	var period: PeriodComponent
 }

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
@@ -125,6 +125,7 @@ extension CareKitEssentialChartable {
 				let combined = CombinedProgress(
 					value: combinedProgressValue,
 					originalValues: combinedProgressValues,
+					originalOutcomeValues: progress.originalOutcomeValues,
 					unit: combinedProgressUnit,
 					date: progress.date,
 					period: progress.period
@@ -136,6 +137,7 @@ extension CareKitEssentialChartable {
 				let combined = CombinedProgress(
 					value: combinedProgressValue,
 					originalValues: combinedProgressValues,
+					originalOutcomeValues: progress.originalOutcomeValues,
 					unit: combinedProgressUnit,
 					date: progress.date,
 					period: progress.period
@@ -147,6 +149,7 @@ extension CareKitEssentialChartable {
 				let combined = CombinedProgress(
 					value: combinedProgressValue,
 					originalValues: combinedProgressValues,
+					originalOutcomeValues: progress.originalOutcomeValues,
 					unit: combinedProgressUnit,
 					date: progress.date,
 					period: progress.period
@@ -163,6 +166,7 @@ extension CareKitEssentialChartable {
 				yUnit: $0.unit,
 				period: $0.period,
 				originalValues: $0.originalValues,
+				originalOutcomeValues: $0.originalOutcomeValues,
 				accessibilityValue: "\(configuration.legendTitle), \($0.date), \($0.value)"
 			)
 		}
@@ -261,17 +265,16 @@ extension CareKitEssentialChartable {
 				computeProgress(event)
 			}
 
-			let valueUnits = events.reduce(into: [String]()) { units, event in
-				guard let currentUnits = event.outcome?.values.compactMap(\.units) else {
-					return
-				}
-				units.append(contentsOf: currentUnits)
+			let values = events.compactMap { $0.outcome?.values }.flatMap { $0 }
+			let valueUnits = values.compactMap( \.units ).reduce(into: [String]()) { units, unit in
+				units.append(unit)
 			}
 			let dateOfPeriodComponent = calendar.date(from: periodComponent.componentsForProgressWithDay)!
 
 			let temporalProgress = TemporalProgress(
 				values: progressForEvents,
 				units: valueUnits,
+				originalOutcomeValues: values,
 				date: dateOfPeriodComponent,
 				period: period
 			)

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
@@ -252,13 +252,22 @@ extension CareKitEssentialChartable {
 			}
 		)
 
-		// Iterate through the events on each component and update the stored progress values
-		let progressPerPeriodComponent = periodComponentsInInterval.map { periodComponent -> TemporalProgress<Progress> in
+		// Iterate through the events on each component and calculate progress values.
+		let progressPerPeriodComponent = periodComponentsInInterval.compactMap { periodComponent -> TemporalProgress<Progress>? in
 
 			let events = eventsGroupedByPeriodComponent[periodComponent.componentsForProgress] ?? []
 
-			let progressForEvents = events.map { event in
-				computeProgress(event)
+			let progressForEvents = events.compactMap { event -> Progress? in
+				// Only compute progress for events that have OCKOutcomeValue's.
+				guard event.outcome?.values.isEmpty == false else {
+					return nil
+				}
+				return computeProgress(event)
+			}
+
+			// Only add progress for events that have OCKOutcomeValue's.
+			guard progressForEvents.isEmpty == false else {
+				return nil
 			}
 
 			let valueUnits = events.reduce(into: [String]()) { units, event in

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
@@ -253,21 +253,12 @@ extension CareKitEssentialChartable {
 		)
 
 		// Iterate through the events on each component and calculate progress values.
-		let progressPerPeriodComponent = periodComponentsInInterval.compactMap { periodComponent -> TemporalProgress<Progress>? in
+		let progressPerPeriodComponent = periodComponentsInInterval.map { periodComponent -> TemporalProgress<Progress> in
 
 			let events = eventsGroupedByPeriodComponent[periodComponent.componentsForProgress] ?? []
 
-			let progressForEvents = events.compactMap { event -> Progress? in
-				// Only compute progress for events that have OCKOutcomeValue's.
-				guard event.outcome?.values.isEmpty == false else {
-					return nil
-				}
-				return computeProgress(event)
-			}
-
-			// Only add progress for events that have OCKOutcomeValue's.
-			guard progressForEvents.isEmpty == false else {
-				return nil
+			let progressForEvents = events.map { event -> Progress in
+				computeProgress(event)
 			}
 
 			let valueUnits = events.reduce(into: [String]()) { units, event in

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialChartBodyView+ChartContent.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialChartBodyView+ChartContent.swift
@@ -13,7 +13,6 @@ extension CareKitEssentialChartBodyView {
 
 	@ChartContentBuilder
 	func makeAllAdditionalMarks(series: CKEDataSeries, at point: CKEPoint) -> some ChartContent {
-		makePointMarksForAllDataPoints(series: series, at: point)
 		makeAdditionalMarksForBarMarks(series: series, at: point)
 	}
 
@@ -77,17 +76,6 @@ extension CareKitEssentialChartBodyView {
 					Text(markerLocalizedString("MEDIAN_VALUE", value: median))
 						.font(.caption)
 				}
-		}
-	}
-
-	@ChartContentBuilder
-	func makePointMarksForAllDataPoints(series: CKEDataSeries, at point: CKEPoint) -> some ChartContent {
-		ForEach(0..<point.originalValues.count, id: \.self) { index in
-			PointMark(
-				x: .value(series.xLabel, point.x, unit: point.xUnit),
-				y: .value(series.yLabel, point.originalValues[index])
-			)
-			.opacity(0.3)
 		}
 	}
 

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialChartBodyView+ChartContent.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialChartBodyView+ChartContent.swift
@@ -54,7 +54,7 @@ extension CareKitEssentialChartBodyView {
 			RuleMark(y: .value("AVERAGE", mean))
 				.foregroundStyle(grayColor.opacity(0.2))
 				.annotation(
-					position: .top,
+					position: .automatic,
 					alignment: .topLeading
 				) {
 					Text(markerLocalizedString("AVERAGE_VALUE", value: mean))
@@ -70,7 +70,7 @@ extension CareKitEssentialChartBodyView {
 			RuleMark(y: .value("MEDIAN", median))
 				.foregroundStyle(.gray.opacity(0.2))
 				.annotation(
-					position: .top,
+					position: .automatic,
 					alignment: .topLeading
 				) {
 					Text(markerLocalizedString("MEDIAN_VALUE", value: median))

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialChartBodyView+ChartContent.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialChartBodyView+ChartContent.swift
@@ -27,6 +27,7 @@ extension CareKitEssentialChartBodyView {
 	@ChartContentBuilder
 	func makeSelectedRuleMark(series: CKEDataSeries) -> some ChartContent {
 		if let selectedDate,
+		   selectedDateValue(series: series) != nil,
 		   let dateUnit = series.dataPoints.first?.xUnit {
 			RuleMark(x: .value("SELECTED_DATE", selectedDate, unit: dateUnit))
 				.foregroundStyle(grayColor.opacity(0.2))

--- a/Sources/CareKitEssentials/Resources/en.lproj/Localizable.strings
+++ b/Sources/CareKitEssentials/Resources/en.lproj/Localizable.strings
@@ -6,8 +6,8 @@
 "AVERAGE" = "Average";
 "MEDIAN" = "Median";
 "SUM" = "SUM";
-"AVERAGE_VALUE" = "Average: %F";
-"MEDIAN_VALUE" = "Median: %F";
+"AVERAGE_VALUE" = "Average: %.2F";
+"MEDIAN_VALUE" = "Median: %.2F";
 "DAY" = "Day";
 "WEEK" = "Week";
 "MONTH" = "Month";


### PR DESCRIPTION
- [x] Allow developer to disable detailed chart view
- [x] Add scatter plot
- [x] Chart views now use a navigation stack instead of modal popover
- [x] Chart details now show in chart view
- [x] Highlighting mark only shows when data isn't zero (a little buggy, will fix in future PR)    