### PR TITLE
feat: Add simple cards for slider and digitalcrown views

### DIFF
--- a/CareKitEssentials.xcodeproj/project.pbxproj
+++ b/CareKitEssentials.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		70721CE62D65990700270799 /* OCKOutcomeValueExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70721CE52D65990700270799 /* OCKOutcomeValueExtensionsTests.swift */; };
 		707D28A22DC815F300980253 /* CareKitEssentialSliderLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */; };
 		707D28A42DC817F700980253 /* CareKitEssentialDigitalCrownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */; };
+		707D28A72DC9116E00980253 /* CareKitEssentialSliderLogView+EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A62DC9116200980253 /* CareKitEssentialSliderLogView+EventViewable.swift */; };
 		7081E0212D050136004937F6 /* CareStoreFetchedResults+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7081E0202D050136004937F6 /* CareStoreFetchedResults+Sequence.swift */; };
 		708D74092DC4995F0049B592 /* OCKOutcomeValue+Plottable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708D74082DC4995A0049B592 /* OCKOutcomeValue+Plottable.swift */; };
 		7094DD0F2DC477EE0039CA64 /* CareKitEssentialVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7094DD0E2DC477E70039CA64 /* CareKitEssentialVersionable.swift */; };
@@ -88,10 +89,10 @@
 		70EBE30D2D19FC0F00517D5E /* EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE30A2D19FC0F00517D5E /* EventViewable.swift */; };
 		70EBE3102D19FC2A00517D5E /* EventQueryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE30F2D19FC2A00517D5E /* EventQueryView.swift */; };
 		70EBE3112D19FC2A00517D5E /* EventQueryContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE30E2D19FC2A00517D5E /* EventQueryContentView.swift */; };
-		70EBE3132D19FF0200517D5E /* SimpleTaskView+CareStoreFetchedViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3122D19FEE600517D5E /* SimpleTaskView+CareStoreFetchedViewable.swift */; };
-		70EBE3152D19FF9700517D5E /* InstructionsTaskView+CareStoreFetchedViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3142D19FF8D00517D5E /* InstructionsTaskView+CareStoreFetchedViewable.swift */; };
-		70EBE3172D19FFE900517D5E /* LabeledValueTaskView+CareStoreFetchedViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3162D19FFE900517D5E /* LabeledValueTaskView+CareStoreFetchedViewable.swift */; };
-		70EBE3192D19FFF700517D5E /* NumericProgressTaskView+CareStoreFetchedViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3182D19FFF700517D5E /* NumericProgressTaskView+CareStoreFetchedViewable.swift */; };
+		70EBE3132D19FF0200517D5E /* SimpleTaskView+EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3122D19FEE600517D5E /* SimpleTaskView+EventViewable.swift */; };
+		70EBE3152D19FF9700517D5E /* InstructionsTaskView+EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3142D19FF8D00517D5E /* InstructionsTaskView+EventViewable.swift */; };
+		70EBE3172D19FFE900517D5E /* LabeledValueTaskView+EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3162D19FFE900517D5E /* LabeledValueTaskView+EventViewable.swift */; };
+		70EBE3192D19FFF700517D5E /* NumericProgressTaskView+EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EBE3182D19FFF700517D5E /* NumericProgressTaskView+EventViewable.swift */; };
 		70FDC6162C387C9F00A32137 /* NSImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70FDC6152C387C9F00A32137 /* NSImage.swift */; };
 		911BDB262A11C437004F8442 /* View+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911BDB252A11C437004F8442 /* View+Default.swift */; };
 		911BDB282A11C491004F8442 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911BDB272A11C491004F8442 /* CGFloat.swift */; };
@@ -210,6 +211,7 @@
 		70721CE52D65990700270799 /* OCKOutcomeValueExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKOutcomeValueExtensionsTests.swift; sourceTree = "<group>"; };
 		707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialSliderLogView.swift; sourceTree = "<group>"; };
 		707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialDigitalCrownView.swift; sourceTree = "<group>"; };
+		707D28A62DC9116200980253 /* CareKitEssentialSliderLogView+EventViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CareKitEssentialSliderLogView+EventViewable.swift"; sourceTree = "<group>"; };
 		7081E0202D050136004937F6 /* CareStoreFetchedResults+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CareStoreFetchedResults+Sequence.swift"; sourceTree = "<group>"; };
 		708D74082DC4995A0049B592 /* OCKOutcomeValue+Plottable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcomeValue+Plottable.swift"; sourceTree = "<group>"; };
 		7094DD0E2DC477E70039CA64 /* CareKitEssentialVersionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialVersionable.swift; sourceTree = "<group>"; };
@@ -251,10 +253,10 @@
 		70EBE30B2D19FC0F00517D5E /* EventWithContentViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventWithContentViewable.swift; sourceTree = "<group>"; };
 		70EBE30E2D19FC2A00517D5E /* EventQueryContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueryContentView.swift; sourceTree = "<group>"; };
 		70EBE30F2D19FC2A00517D5E /* EventQueryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueryView.swift; sourceTree = "<group>"; };
-		70EBE3122D19FEE600517D5E /* SimpleTaskView+CareStoreFetchedViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimpleTaskView+CareStoreFetchedViewable.swift"; sourceTree = "<group>"; };
-		70EBE3142D19FF8D00517D5E /* InstructionsTaskView+CareStoreFetchedViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstructionsTaskView+CareStoreFetchedViewable.swift"; sourceTree = "<group>"; };
-		70EBE3162D19FFE900517D5E /* LabeledValueTaskView+CareStoreFetchedViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LabeledValueTaskView+CareStoreFetchedViewable.swift"; sourceTree = "<group>"; };
-		70EBE3182D19FFF700517D5E /* NumericProgressTaskView+CareStoreFetchedViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumericProgressTaskView+CareStoreFetchedViewable.swift"; sourceTree = "<group>"; };
+		70EBE3122D19FEE600517D5E /* SimpleTaskView+EventViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimpleTaskView+EventViewable.swift"; sourceTree = "<group>"; };
+		70EBE3142D19FF8D00517D5E /* InstructionsTaskView+EventViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstructionsTaskView+EventViewable.swift"; sourceTree = "<group>"; };
+		70EBE3162D19FFE900517D5E /* LabeledValueTaskView+EventViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LabeledValueTaskView+EventViewable.swift"; sourceTree = "<group>"; };
+		70EBE3182D19FFF700517D5E /* NumericProgressTaskView+EventViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumericProgressTaskView+EventViewable.swift"; sourceTree = "<group>"; };
 		70FDC6152C387C9F00A32137 /* NSImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSImage.swift; sourceTree = "<group>"; };
 		911BDB252A11C437004F8442 /* View+Default.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+Default.swift"; sourceTree = "<group>"; };
 		911BDB272A11C491004F8442 /* CGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
@@ -411,15 +413,16 @@
 			isa = PBXGroup;
 			children = (
 				70116B3F2DC06DBC0024BB89 /* CareKitEssentialChartBodyView+ChartContent.swift */,
+				707D28A62DC9116200980253 /* CareKitEssentialSliderLogView+EventViewable.swift */,
 				70116AF02DBC632E0024BB89 /* CKEDataSeries+AXChartDescriptorRepresentable.swift */,
 				91A9E7E12A197A7300F3414D /* InstructionsTaskView.swift */,
-				70EBE3142D19FF8D00517D5E /* InstructionsTaskView+CareStoreFetchedViewable.swift */,
+				70EBE3142D19FF8D00517D5E /* InstructionsTaskView+EventViewable.swift */,
 				91A9E7DF2A19784800F3414D /* LabeledValueTaskView.swift */,
-				70EBE3162D19FFE900517D5E /* LabeledValueTaskView+CareStoreFetchedViewable.swift */,
+				70EBE3162D19FFE900517D5E /* LabeledValueTaskView+EventViewable.swift */,
 				91A9E7DD2A19758300F3414D /* NumericProgressTaskView.swift */,
-				70EBE3182D19FFF700517D5E /* NumericProgressTaskView+CareStoreFetchedViewable.swift */,
+				70EBE3182D19FFF700517D5E /* NumericProgressTaskView+EventViewable.swift */,
 				91A9E7E32A197A9300F3414D /* SimpleTaskView.swift */,
-				70EBE3122D19FEE600517D5E /* SimpleTaskView+CareStoreFetchedViewable.swift */,
+				70EBE3122D19FEE600517D5E /* SimpleTaskView+EventViewable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -462,8 +465,8 @@
 		70BBCB4F2A12BD2500759A9C /* SliderLog */ = {
 			isa = PBXGroup;
 			children = (
-				70BBCB522A12BDAC00759A9C /* Slider.swift */,
 				707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */,
+				70BBCB522A12BDAC00759A9C /* Slider.swift */,
 				70BBCB542A12BDBD00759A9C /* SliderLogButton.swift */,
 				70BBCB4D2A12BB0500759A9C /* SliderLogTaskView.swift */,
 				70BBCB562A14164E00759A9C /* SliderLogTaskViewModel.swift */,
@@ -521,8 +524,8 @@
 		OBJ_14 /* DigitalCrown */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_15 /* DigitalCrownView.swift */,
 				707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */,
+				OBJ_15 /* DigitalCrownView.swift */,
 				OBJ_16 /* DigitalCrownViewFooter.swift */,
 				OBJ_17 /* DigitalCrownViewHeader.swift */,
 				OBJ_18 /* DigitalCrownViewModel.swift */,
@@ -840,6 +843,7 @@
 				70EBE3102D19FC2A00517D5E /* EventQueryView.swift in Sources */,
 				70EBE3112D19FC2A00517D5E /* EventQueryContentView.swift in Sources */,
 				702FF7712CFAA96B00B26710 /* CKEPoint.swift in Sources */,
+				707D28A72DC9116E00980253 /* CareKitEssentialSliderLogView+EventViewable.swift in Sources */,
 				70721CE42D658EC300270799 /* OCKOutcomeValue+Sequence.swift in Sources */,
 				700DA9052C2A609600435E2C /* CareKitEssentialView.swift in Sources */,
 				70B49A602D06A2520023E5B3 /* SimpleLabelView.swift in Sources */,
@@ -851,7 +855,7 @@
 				708D74092DC4995F0049B592 /* OCKOutcomeValue+Plottable.swift in Sources */,
 				7026DDF72D0D2B33002EACAA /* OCKAnyEvent+Equatable.swift in Sources */,
 				OBJ_742 /* DetailsView.swift in Sources */,
-				70EBE3172D19FFE900517D5E /* LabeledValueTaskView+CareStoreFetchedViewable.swift in Sources */,
+				70EBE3172D19FFE900517D5E /* LabeledValueTaskView+EventViewable.swift in Sources */,
 				91A9E7E02A19784800F3414D /* LabeledValueTaskView.swift in Sources */,
 				70116AF92DBDF5E30024BB89 /* CareKitEssentialChartable.swift in Sources */,
 				70B49A7D2D0A53FA0023E5B3 /* OCKAnyEvent+Hashable.swift in Sources */,
@@ -870,10 +874,10 @@
 				OBJ_750 /* CardViewModel.swift in Sources */,
 				7094DD172DC47DC80039CA64 /* OCKHealthKitOutcome+Hashable.swift in Sources */,
 				702FF76B2CFAA93C00B26710 /* CareKitEssentialChartView.swift in Sources */,
-				70EBE3192D19FFF700517D5E /* NumericProgressTaskView+CareStoreFetchedViewable.swift in Sources */,
+				70EBE3192D19FFF700517D5E /* NumericProgressTaskView+EventViewable.swift in Sources */,
 				702FF7752CFAA97800B26710 /* TemporalTaskProgress.swift in Sources */,
 				7068BD3F2D6277C500212E4A /* OCKHealthKitTask+Hashable.swift in Sources */,
-				70EBE3152D19FF9700517D5E /* InstructionsTaskView+CareStoreFetchedViewable.swift in Sources */,
+				70EBE3152D19FF9700517D5E /* InstructionsTaskView+EventViewable.swift in Sources */,
 				702FF76D2CFAA96100B26710 /* CKEDataSeries.swift in Sources */,
 				91A9E7E22A197A7300F3414D /* InstructionsTaskView.swift in Sources */,
 				OBJ_752 /* Calendar+Dates.swift in Sources */,
@@ -905,7 +909,7 @@
 				70C422CA2C3B681A00E6DC51 /* OCKAnyOutcome+Sequence.swift in Sources */,
 				911BDB342A130AF9004F8442 /* OCKStore.swift in Sources */,
 				70116B3C2DC067240024BB89 /* BinaryCareTaskProgress+Math.swift in Sources */,
-				70EBE3132D19FF0200517D5E /* SimpleTaskView+CareStoreFetchedViewable.swift in Sources */,
+				70EBE3132D19FF0200517D5E /* SimpleTaskView+EventViewable.swift in Sources */,
 				OBJ_757 /* OCKBiologicalSex+Hashable.swift in Sources */,
 				7026DDED2D0CD600002EACAA /* OCKSemanticVersion+Hashable.swift in Sources */,
 				7068BD412D62788E00212E4A /* OCKHealthKitLinkage+Hashable.swift in Sources */,

--- a/CareKitEssentials.xcodeproj/project.pbxproj
+++ b/CareKitEssentials.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		7068BD412D62788E00212E4A /* OCKHealthKitLinkage+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7068BD402D62788A00212E4A /* OCKHealthKitLinkage+Hashable.swift */; };
 		70721CE42D658EC300270799 /* OCKOutcomeValue+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70721CE32D658EBC00270799 /* OCKOutcomeValue+Sequence.swift */; };
 		70721CE62D65990700270799 /* OCKOutcomeValueExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70721CE52D65990700270799 /* OCKOutcomeValueExtensionsTests.swift */; };
+		707D28A22DC815F300980253 /* CareKitEssentialSliderLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */; };
+		707D28A42DC817F700980253 /* CareKitEssentialDigitalCrownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */; };
 		7081E0212D050136004937F6 /* CareStoreFetchedResults+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7081E0202D050136004937F6 /* CareStoreFetchedResults+Sequence.swift */; };
 		708D74092DC4995F0049B592 /* OCKOutcomeValue+Plottable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708D74082DC4995A0049B592 /* OCKOutcomeValue+Plottable.swift */; };
 		7094DD0F2DC477EE0039CA64 /* CareKitEssentialVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7094DD0E2DC477E70039CA64 /* CareKitEssentialVersionable.swift */; };
@@ -206,6 +208,8 @@
 		7068BD402D62788A00212E4A /* OCKHealthKitLinkage+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKHealthKitLinkage+Hashable.swift"; sourceTree = "<group>"; };
 		70721CE32D658EBC00270799 /* OCKOutcomeValue+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcomeValue+Sequence.swift"; sourceTree = "<group>"; };
 		70721CE52D65990700270799 /* OCKOutcomeValueExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKOutcomeValueExtensionsTests.swift; sourceTree = "<group>"; };
+		707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialSliderLogView.swift; sourceTree = "<group>"; };
+		707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialDigitalCrownView.swift; sourceTree = "<group>"; };
 		7081E0202D050136004937F6 /* CareStoreFetchedResults+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CareStoreFetchedResults+Sequence.swift"; sourceTree = "<group>"; };
 		708D74082DC4995A0049B592 /* OCKOutcomeValue+Plottable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcomeValue+Plottable.swift"; sourceTree = "<group>"; };
 		7094DD0E2DC477E70039CA64 /* CareKitEssentialVersionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialVersionable.swift; sourceTree = "<group>"; };
@@ -459,6 +463,7 @@
 			isa = PBXGroup;
 			children = (
 				70BBCB522A12BDAC00759A9C /* Slider.swift */,
+				707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */,
 				70BBCB542A12BDBD00759A9C /* SliderLogButton.swift */,
 				70BBCB4D2A12BB0500759A9C /* SliderLogTaskView.swift */,
 				70BBCB562A14164E00759A9C /* SliderLogTaskViewModel.swift */,
@@ -517,6 +522,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_15 /* DigitalCrownView.swift */,
+				707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */,
 				OBJ_16 /* DigitalCrownViewFooter.swift */,
 				OBJ_17 /* DigitalCrownViewHeader.swift */,
 				OBJ_18 /* DigitalCrownViewModel.swift */,
@@ -905,6 +911,7 @@
 				7068BD412D62788E00212E4A /* OCKHealthKitLinkage+Hashable.swift in Sources */,
 				7026DDEF2D0CD750002EACAA /* OCKNote+Hashable.swift in Sources */,
 				OBJ_758 /* LinearCareTaskProgress+Math.swift in Sources */,
+				707D28A42DC817F700980253 /* CareKitEssentialDigitalCrownView.swift in Sources */,
 				70BBCB572A14164E00759A9C /* SliderLogTaskViewModel.swift in Sources */,
 				7094DD152DC47C790039CA64 /* OCKContact+Hashable.swift in Sources */,
 				70CA3AFA2DB8C28E002CDC50 /* OCKStoreCoordinator+Hashable.swift in Sources */,
@@ -914,6 +921,7 @@
 				702FF7812CFE5B0400B26710 /* ChartContent+Default.swift in Sources */,
 				911BDB262A11C437004F8442 /* View+Default.swift in Sources */,
 				70116AF52DBDC5B10024BB89 /* DateComponentsForProgress.swift in Sources */,
+				707D28A22DC815F300980253 /* CareKitEssentialSliderLogView.swift in Sources */,
 				911BDB322A130A2B004F8442 /* Utility.swift in Sources */,
 				709530B32DAC3AFB00E18A59 /* SurveyQuestion.swift in Sources */,
 				709530B42DAC3AFB00E18A59 /* SurveyStep.swift in Sources */,

--- a/CareKitEssentials.xcodeproj/project.pbxproj
+++ b/CareKitEssentials.xcodeproj/project.pbxproj
@@ -46,8 +46,8 @@
 		70721CE42D658EC300270799 /* OCKOutcomeValue+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70721CE32D658EBC00270799 /* OCKOutcomeValue+Sequence.swift */; };
 		70721CE62D65990700270799 /* OCKOutcomeValueExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70721CE52D65990700270799 /* OCKOutcomeValueExtensionsTests.swift */; };
 		707D28A22DC815F300980253 /* CareKitEssentialSliderLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */; };
-		707D28A42DC817F700980253 /* CareKitEssentialDigitalCrownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */; };
 		707D28A72DC9116E00980253 /* CareKitEssentialSliderLogView+EventViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A62DC9116200980253 /* CareKitEssentialSliderLogView+EventViewable.swift */; };
+		707D28A92DC93EE100980253 /* CareKitEssentialDigitalCrownLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28A82DC93EE100980253 /* CareKitEssentialDigitalCrownLogView.swift */; };
 		7081E0212D050136004937F6 /* CareStoreFetchedResults+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7081E0202D050136004937F6 /* CareStoreFetchedResults+Sequence.swift */; };
 		708D74092DC4995F0049B592 /* OCKOutcomeValue+Plottable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708D74082DC4995A0049B592 /* OCKOutcomeValue+Plottable.swift */; };
 		7094DD0F2DC477EE0039CA64 /* CareKitEssentialVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7094DD0E2DC477E70039CA64 /* CareKitEssentialVersionable.swift */; };
@@ -210,8 +210,8 @@
 		70721CE32D658EBC00270799 /* OCKOutcomeValue+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcomeValue+Sequence.swift"; sourceTree = "<group>"; };
 		70721CE52D65990700270799 /* OCKOutcomeValueExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKOutcomeValueExtensionsTests.swift; sourceTree = "<group>"; };
 		707D28A12DC815DA00980253 /* CareKitEssentialSliderLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialSliderLogView.swift; sourceTree = "<group>"; };
-		707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialDigitalCrownView.swift; sourceTree = "<group>"; };
 		707D28A62DC9116200980253 /* CareKitEssentialSliderLogView+EventViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CareKitEssentialSliderLogView+EventViewable.swift"; sourceTree = "<group>"; };
+		707D28A82DC93EE100980253 /* CareKitEssentialDigitalCrownLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialDigitalCrownLogView.swift; sourceTree = "<group>"; };
 		7081E0202D050136004937F6 /* CareStoreFetchedResults+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CareStoreFetchedResults+Sequence.swift"; sourceTree = "<group>"; };
 		708D74082DC4995A0049B592 /* OCKOutcomeValue+Plottable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcomeValue+Plottable.swift"; sourceTree = "<group>"; };
 		7094DD0E2DC477E70039CA64 /* CareKitEssentialVersionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareKitEssentialVersionable.swift; sourceTree = "<group>"; };
@@ -524,7 +524,7 @@
 		OBJ_14 /* DigitalCrown */ = {
 			isa = PBXGroup;
 			children = (
-				707D28A32DC817EC00980253 /* CareKitEssentialDigitalCrownView.swift */,
+				707D28A82DC93EE100980253 /* CareKitEssentialDigitalCrownLogView.swift */,
 				OBJ_15 /* DigitalCrownView.swift */,
 				OBJ_16 /* DigitalCrownViewFooter.swift */,
 				OBJ_17 /* DigitalCrownViewHeader.swift */,
@@ -885,6 +885,7 @@
 				OBJ_753 /* Image.swift in Sources */,
 				70EBE30C2D19FC0F00517D5E /* EventWithContentViewable.swift in Sources */,
 				70EBE30D2D19FC0F00517D5E /* EventViewable.swift in Sources */,
+				707D28A92DC93EE100980253 /* CareKitEssentialDigitalCrownLogView.swift in Sources */,
 				709530B62DAC3CA300E18A59 /* OCKTask+ResearchKitSwiftUI.swift in Sources */,
 				70B49A892D0A83E10023E5B3 /* Double.swift in Sources */,
 				702FF7732CFAA97500B26710 /* TemporalProgress.swift in Sources */,
@@ -915,7 +916,6 @@
 				7068BD412D62788E00212E4A /* OCKHealthKitLinkage+Hashable.swift in Sources */,
 				7026DDEF2D0CD750002EACAA /* OCKNote+Hashable.swift in Sources */,
 				OBJ_758 /* LinearCareTaskProgress+Math.swift in Sources */,
-				707D28A42DC817F700980253 /* CareKitEssentialDigitalCrownView.swift in Sources */,
 				70BBCB572A14164E00759A9C /* SliderLogTaskViewModel.swift in Sources */,
 				7094DD152DC47C790039CA64 /* OCKContact+Hashable.swift in Sources */,
 				70CA3AFA2DB8C28E002CDC50 /* OCKStoreCoordinator+Hashable.swift in Sources */,

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/CareKitEssentialChartView.swift
@@ -13,6 +13,8 @@ import Foundation
 import os.log
 import SwiftUI
 
+public typealias ChartView = CareKitEssentialChartView
+
 /// Displays a SwiftUI Chart above an axis. The initializer takes an an array of
 /// `CKEDataSeriesConfiguration`'s which each support
 /// `CKEDataSeries.MarkType` that allows you to overlay from several
@@ -179,7 +181,7 @@ struct CareKitEssentialChartView_Previews: PreviewProvider {
 
 		NavigationStack {
 			ScrollView {
-				CareKitEssentialChartView(
+				ChartView(
 					title: task.title ?? "",
 					subtitle: "Chart",
 					dateInterval: $dateInterval,

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeriesConfiguration.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Data/CKEDataSeriesConfiguration.swift
@@ -15,10 +15,18 @@ import Charts
 /// A configuration object that specifies which data should be queried and how it should be displayed by the graph.
 public struct CKEDataSeriesConfiguration: Identifiable, Hashable {
 
+	/// The type of strategy used to produce each data point in the plot.
 	public enum DataStrategy: Hashable {
+		/// Take the sum of all `OCKOutcomeValues` to produce each data point.
 		case sum
+		/// Take the maximum of all `OCKOutcomeValues` to produce each data point.
+		case max
+		/// Take the mean of all `OCKOutcomeValues` to produce each data point.
 		case mean
+		/// Take the median of all `OCKOutcomeValues` to produce each data point.
 		case median
+		/// Take the minimum of all `OCKOutcomeValues` to produce each data point.
+		case min
 	}
 
     public var id: String {
@@ -28,7 +36,7 @@ public struct CKEDataSeriesConfiguration: Identifiable, Hashable {
     /// The type of mark to display for this configuration.
     public var mark: CKEDataSeries.MarkType
 
-	/// The type of strategy used to combine the date the plot.
+	/// The type of strategy used to produce each data point in the plot.
 	public var dataStrategy: DataStrategy
 
     /// A user-provided unique id for a task.
@@ -85,8 +93,8 @@ public struct CKEDataSeriesConfiguration: Identifiable, Hashable {
     /// Initialize a new `CareKitEssentialsDataSeriesConfiguration`.
     ///
     /// - Parameters:
-    ///   - taskID: A user-provided unique id for a task.
-	///   - dataStrategy: The type of strategy used to combine the date the plot. Be sure
+    ///	  - taskID: A user-provided unique id for a task.
+	///   - dataStrategy: The type of strategy used to produce each data point in the plot. Be sure
 	///   the `dataStrategy` matches the same strategy used for `computeProgress`.
 	///   - kind: The kind property of the OCKOutcomeValue to graph.
     ///   - mark: The type of mark to display for this configuration.

--- a/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Chart/Protocols/CareKitEssentialChartable.swift
@@ -131,6 +131,28 @@ extension CareKitEssentialChartable {
 					period: progress.period
 				)
 				return combined
+			case .max:
+				let combinedProgressValue = combinedProgressValues.max() ?? 0
+				let combined = CombinedProgress(
+					value: combinedProgressValue,
+					originalValues: combinedProgressValues,
+					originalOutcomeValues: progress.originalOutcomeValues,
+					unit: combinedProgressUnit,
+					date: progress.date,
+					period: progress.period
+				)
+				return combined
+			case .min:
+				let combinedProgressValue = combinedProgressValues.min() ?? 0
+				let combined = CombinedProgress(
+					value: combinedProgressValue,
+					originalValues: combinedProgressValues,
+					originalOutcomeValues: progress.originalOutcomeValues,
+					unit: combinedProgressUnit,
+					date: progress.date,
+					period: progress.period
+				)
+				return combined
 			case .mean:
 				let combinedProgressValue = LinearCareTaskProgress.computeProgressByAveraging(for: combinedProgressValues).value
 

--- a/Sources/CareKitEssentials/Cards/Shared/DismissableView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/DismissableView.swift
@@ -13,7 +13,7 @@ struct DismissableView<Content: View>: View {
 	@ViewBuilder var content: Content
 
 	var body: some View {
-		NavigationStack {
+		NavigationView {
 			content
 				#if !os(watchOS) && !os(macOS)
 				.toolbar {

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialSliderLogView+EventViewable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/CareKitEssentialSliderLogView+EventViewable.swift
@@ -1,0 +1,25 @@
+//
+//  CareKitEssentialSliderLogView+EventViewable.swift
+//  CareKitEssentials
+//
+//  Created by Corey Baker on 5/5/25.
+//  Copyright © 2025 Network Reconnaissance Lab. All rights reserved.
+//
+
+#if !os(watchOS)
+
+import CareKitStore
+
+extension CareKitEssentialSliderLogView: EventViewable {
+
+	public init?(
+		event: OCKAnyEvent,
+		store: any OCKAnyStoreProtocol
+	) {
+		self.init(
+			event: event
+		)
+	}
+}
+
+#endif

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/InstructionsTaskView+EventViewable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/InstructionsTaskView+EventViewable.swift
@@ -1,10 +1,12 @@
 //
-//  SimpleTaskView+CareStoreFetchedViewable.swift
+//  InstructionsTaskView+EventViewable.swift
 //  CareKitEssentials
 //
 //  Created by Corey Baker on 12/23/24.
 //  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
 //
+
+#if !os(watchOS)
 
 import CareKit
 import CareKitStore
@@ -13,9 +15,7 @@ import Foundation
 import SwiftUI
 import os.log
 
-#if !os(watchOS)
-
-extension SimpleTaskView: EventViewable where Header == InformationHeaderView {
+extension InstructionsTaskView: EventViewable where Header == InformationHeaderView {
     public init?(
         event: OCKAnyEvent,
         store: OCKAnyStoreProtocol
@@ -24,7 +24,7 @@ extension SimpleTaskView: EventViewable where Header == InformationHeaderView {
             event: event,
             store: store,
             onError: { error in
-                Logger.simpleTaskView.error("\(error)")
+                Logger.instructionsTaskView.error("\(error)")
             }
         )
     }

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/LabeledValueTaskView+EventViewable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/LabeledValueTaskView+EventViewable.swift
@@ -1,5 +1,5 @@
 //
-//  NumericProgressTaskView+CareStoreFetchedViewable.swift
+//  LabeledValueTaskView+EventViewable.swift
 //  CareKitEssentials
 //
 //  Created by Corey Baker on 12/10/24.
@@ -12,7 +12,7 @@ import CareKit
 import CareKitStore
 import CareKitUI
 
-extension NumericProgressTaskView: EventViewable where Header == InformationHeaderView {
+extension LabeledValueTaskView: EventViewable where Header == InformationHeaderView {
     public init?(
         event: OCKAnyEvent,
         store: OCKAnyStoreProtocol

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/NumericProgressTaskView+EventViewable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/NumericProgressTaskView+EventViewable.swift
@@ -1,5 +1,5 @@
 //
-//  LabeledValueTaskView+CareStoreFetchedViewable.swift
+//  NumericProgressTaskView+EventViewable.swift
 //  CareKitEssentials
 //
 //  Created by Corey Baker on 12/10/24.
@@ -12,7 +12,7 @@ import CareKit
 import CareKitStore
 import CareKitUI
 
-extension LabeledValueTaskView: EventViewable where Header == InformationHeaderView {
+extension NumericProgressTaskView: EventViewable where Header == InformationHeaderView {
     public init?(
         event: OCKAnyEvent,
         store: OCKAnyStoreProtocol

--- a/Sources/CareKitEssentials/Cards/Shared/Extensions/SimpleTaskView+EventViewable.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/Extensions/SimpleTaskView+EventViewable.swift
@@ -1,10 +1,12 @@
 //
-//  InstructionsTaskView+CareStoreFetchedViewable.swift
+//  SimpleTaskView+EventViewable.swift
 //  CareKitEssentials
 //
 //  Created by Corey Baker on 12/23/24.
 //  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
 //
+
+#if !os(watchOS)
 
 import CareKit
 import CareKitStore
@@ -13,9 +15,7 @@ import Foundation
 import SwiftUI
 import os.log
 
-#if !os(watchOS)
-
-extension InstructionsTaskView: EventViewable where Header == InformationHeaderView {
+extension SimpleTaskView: EventViewable where Header == InformationHeaderView {
     public init?(
         event: OCKAnyEvent,
         store: OCKAnyStoreProtocol
@@ -24,7 +24,7 @@ extension InstructionsTaskView: EventViewable where Header == InformationHeaderV
             event: event,
             store: store,
             onError: { error in
-                Logger.instructionsTaskView.error("\(error)")
+                Logger.simpleTaskView.error("\(error)")
             }
         )
     }

--- a/Sources/CareKitEssentials/Cards/Shared/InformationHeaderView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/InformationHeaderView.swift
@@ -115,11 +115,13 @@ public struct InformationHeaderView: View {
 			isShowingDetails.toggle()
 		}
         .sheet(isPresented: $isShowingDetails) {
-            DetailsView(
-				event: event,
-				title: detailsTitle,
-				details: details
-			)
+			DismissableView {
+				DetailsView(
+					event: event,
+					title: detailsTitle,
+					details: details
+				)
+			}
         }
 
     }

--- a/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
@@ -14,22 +14,53 @@ import CareKitUI
 import os.log
 import SwiftUI
 
-struct CareKitEssentialSliderLogView: CareKitEssentialView {
-	@Environment(\.careStore) var store
+public typealias SliderLogView = CareKitEssentialSliderLogView
 
-	let event: OCKAnyEvent
-	var sliderStyle: SliderStyle
-	var range: ClosedRange<Double>
-	var kind: String?
-	var initialValue: Double?
-	var step: Double
-	var minimumImage: Image?
-	var maximumImage: Image?
-	var minimumDescription: String?
-	var maximumDescription: String?
-	var gradientColors: [Color]?
+/// A card that displays a header view, multi-line label, a slider, and a completion button.
+///
+/// In CareKit, this view is intended to display a particular event for a task.
+/// The state of the button indicates the completion state of the event.
+///
+/// # Style
+/// The card supports styling using `careKitStyle(_:)`.
+///
+/// ```
+///     +-------------------------------------------------------+
+///     |                                                       |
+///     |  <Image> <Title>                       <Info Image>   |
+///     |  <Information>                                        |
+///     |                                                       |
+///     |  --------------------------------------------------   |
+///     |                                                       |
+///     |  <Instructions>                                       |
+///     |                                                       |
+///     |  <Min Image> –––––––––––––O–––––––––––– <Max Image>   |
+///     |             <Min Desc>        <Max Desc>              |
+///     |                                                       |
+///     |  +-------------------------------------------------+  |
+///     |  |                      <Log>                      |  |
+///     |  +-------------------------------------------------+  |
+///     |                                                       |
+///     |                   <Latest Value: >                    |
+///     |                                                       |
+///     +-------------------------------------------------------+
+/// ```
+public struct CareKitEssentialSliderLogView: CareKitEssentialView {
+	@Environment(\.careStore) public var store
 
-	var body: some View {
+	private(set) var event: OCKAnyEvent
+	@State public var sliderStyle: SliderStyle
+	@State public var range: ClosedRange<Double>
+	@State public var kind: String?
+	@State public var initialValue: Double?
+	@State public var step: Double
+	@State public var minimumImage: Image?
+	@State public var maximumImage: Image?
+	@State public var minimumDescription: String?
+	@State public var maximumDescription: String?
+	@State public var gradientColors: [Color]?
+
+	public var body: some View {
 		SliderLogTaskView(
 			title: Text(event.title),
 			detail: event.detailText,
@@ -88,7 +119,7 @@ struct CareKitEssentialSliderLogView: CareKitEssentialView {
 	 drawn. Defaults to nil. An example usage would set an array of red and green to
 	 visually indicate a scale from bad to good.
 	 */
-	init(
+	public init(
 		event: OCKAnyEvent,
 		kind: String? = nil,
 		range: ClosedRange<Double> = 0...10,
@@ -124,20 +155,23 @@ struct CareKitEssentialSliderLogView_Previews: PreviewProvider {
 	}
 
 	static var previews: some View {
-		VStack {
-			if let event = try? Utility.createNauseaEvent() {
-				CareKitEssentialSliderLogView(
-					event: event,
-					style: .ticked,
-					gradientColors: [.green, .yellow, .red]
-				)
-				Divider()
-				CareKitEssentialSliderLogView(
-					event: event,
-					style: .system,
-					gradientColors: [.green, .yellow, .red]
-				)
+		ScrollView {
+			VStack {
+				if let event = try? Utility.createNauseaEvent() {
+					CareKitEssentialSliderLogView(
+						event: event,
+						style: .ticked,
+						gradientColors: [.green, .yellow, .red]
+					)
+					Divider()
+					CareKitEssentialSliderLogView(
+						event: event,
+						style: .system,
+						gradientColors: [.green, .yellow, .red]
+					)
+				}
 			}
+			.padding()
 		}
 		.environment(\.careStore, store)
 		.accentColor(.pink)

--- a/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
@@ -1,0 +1,159 @@
+//
+//  CareKitEssentialSliderLogView.swift
+//  CareKitEssentials
+//
+//  Created by Corey Baker on 5/4/25.
+//  Copyright © 2025 Network Reconnaissance Lab. All rights reserved.
+//
+
+#if !os(watchOS)
+
+import CareKit
+import CareKitStore
+import CareKitUI
+import os.log
+import SwiftUI
+
+struct CareKitEssentialSliderLogView: CareKitEssentialView {
+	@Environment(\.careStore) var store
+
+	let event: OCKAnyEvent
+	var sliderStyle: SliderStyle
+	var range: ClosedRange<Double>
+	var kind: String?
+	var initialValue: Double?
+	var step: Double
+	var minimumImage: Image?
+	var maximumImage: Image?
+	var minimumDescription: String?
+	var maximumDescription: String?
+	var gradientColors: [Color]?
+
+	var body: some View {
+		SliderLogTaskView(
+			title: Text(event.title),
+			detail: event.detailText,
+			instructions: event.instructionsText,
+			viewModel: .init(
+				event: event,
+				kind: kind,
+				detailsTitle: event.detail,
+				detailsInformation: event.instructions,
+				initialValue: initialValue,
+				range: range,
+				step: step,
+				action: { value -> OCKAnyOutcome in
+					guard let value else {
+						// Delete outcome values
+						let updatedOutcome = try await updateEvent(
+							event,
+							with: nil
+						)
+						return updatedOutcome
+					}
+
+					let updatedOutcome = try await updateEvent(
+						event,
+						with: [value]
+					)
+					return updatedOutcome
+				}
+			),
+			style: sliderStyle,
+			gradientColors: gradientColors,
+		)
+	}
+
+	/**
+	 Create an instance with specified content for an event.
+	 - parameter event: A event to associate with the view model.
+	 - parameter kind: The kind of outcome value for the slider. Defaults to nil.
+	 - parameter initialValue: The initial value shown on the slider.
+	 - parameter range: The range that includes all possible values.
+	 - parameter step: Value to increment the slider by. Default value is 1.
+	 - parameter style: The style of the slider, either the SwiftUI system slider or
+	 the custom bar slider.
+	 - parameter minimumImage: Image to display to the left of the slider. Default
+	 value is nil.
+	 - parameter maximumImage: Image to display to the right of the slider. Default
+	 value is nil.
+	 - parameter minimumDescription: Description to display next to lower bound
+	 value. Default value is nil.
+	 - parameter maximumDescription: Description to display next to upper
+	 bound value. Default value is nil.
+	 - parameter gradientColors: The colors to use when drawing a color
+	 gradient inside the slider. Colors are drawn such that lower indexes correspond to the
+	 minimum side of the scale, while colors at higher indexes in the array correspond to
+	 the maximum side of the scale. Setting this value to nil results in no gradient being
+	 drawn. Defaults to nil. An example usage would set an array of red and green to 	visually indicate a scale from bad to good.
+	 */
+	init(
+		event: OCKAnyEvent,
+		kind: String? = nil,
+		range: ClosedRange<Double> = 0...10,
+		initialValue: Double? = nil,
+		step: Double = 1,
+		style: SliderStyle = .system,
+		minimumImage: Image? = nil,
+		maximumImage: Image? = nil,
+		minimumDescription: String? = nil,
+		maximumDescription: String? = nil,
+		gradientColors: [Color]? = nil
+	) {
+		self.event = event
+		self.sliderStyle = style
+		self.range = range
+		self.kind = kind
+		self.initialValue = initialValue
+		self.step = step
+		self.minimumImage = minimumImage
+		self.maximumImage = maximumImage
+		self.minimumDescription = minimumDescription
+		self.maximumDescription = maximumDescription
+		self.gradientColors = gradientColors
+	}
+}
+
+extension CareKitEssentialSliderLogView: EventViewable {
+
+	public init?(
+		event: OCKAnyEvent,
+		store: any OCKAnyStoreProtocol
+	) {
+		self.init(
+			event: event
+		)
+	}
+}
+
+struct CareKitEssentialSliderLogView_Previews: PreviewProvider {
+	static var store = Utility.createPreviewStore()
+	static var query: OCKEventQuery {
+		var query = OCKEventQuery(for: Date())
+		query.taskIDs = [TaskID.nausea]
+		return query
+	}
+
+	static var previews: some View {
+		VStack {
+			if let event = try? Utility.createNauseaEvent() {
+				CareKitEssentialSliderLogView(
+					event: event,
+					style: .ticked,
+					gradientColors: [.green, .yellow, .red]
+				)
+				Divider()
+				CareKitEssentialSliderLogView(
+					event: event,
+					style: .system,
+					gradientColors: [.green, .yellow, .red]
+				)
+			}
+		}
+		.environment(\.careStore, store)
+		.accentColor(.pink)
+		.padding()
+	}
+}
+
+#endif

--- a/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
@@ -48,17 +48,17 @@ public typealias SliderLogView = CareKitEssentialSliderLogView
 public struct CareKitEssentialSliderLogView: CareKitEssentialView {
 	@Environment(\.careStore) public var store
 
-	private(set) var event: OCKAnyEvent
-	@State public var sliderStyle: SliderStyle
-	@State public var range: ClosedRange<Double>
-	@State public var kind: String?
-	@State public var initialValue: Double?
-	@State public var step: Double
-	@State public var minimumImage: Image?
-	@State public var maximumImage: Image?
-	@State public var minimumDescription: String?
-	@State public var maximumDescription: String?
-	@State public var gradientColors: [Color]?
+	var event: OCKAnyEvent
+	var sliderStyle: SliderStyle
+	var range: ClosedRange<Double>
+	var kind: String?
+	var initialValue: Double?
+	var step: Double
+	var minimumImage: Image?
+	var maximumImage: Image?
+	var minimumDescription: String?
+	var maximumDescription: String?
+	var gradientColors: [Color]?
 
 	public var body: some View {
 		SliderLogTaskView(
@@ -158,13 +158,14 @@ struct CareKitEssentialSliderLogView_Previews: PreviewProvider {
 		ScrollView {
 			VStack {
 				if let event = try? Utility.createNauseaEvent() {
-					CareKitEssentialSliderLogView(
+					SliderLogView(
 						event: event,
+						initialValue: 1,
 						style: .ticked,
 						gradientColors: [.green, .yellow, .red]
 					)
 					Divider()
-					CareKitEssentialSliderLogView(
+					SliderLogView(
 						event: event,
 						style: .system,
 						gradientColors: [.green, .yellow, .red]

--- a/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/SliderLog/CareKitEssentialSliderLogView.swift
@@ -85,7 +85,8 @@ struct CareKitEssentialSliderLogView: CareKitEssentialView {
 	 gradient inside the slider. Colors are drawn such that lower indexes correspond to the
 	 minimum side of the scale, while colors at higher indexes in the array correspond to
 	 the maximum side of the scale. Setting this value to nil results in no gradient being
-	 drawn. Defaults to nil. An example usage would set an array of red and green to 	visually indicate a scale from bad to good.
+	 drawn. Defaults to nil. An example usage would set an array of red and green to
+	 visually indicate a scale from bad to good.
 	 */
 	init(
 		event: OCKAnyEvent,
@@ -111,18 +112,6 @@ struct CareKitEssentialSliderLogView: CareKitEssentialView {
 		self.minimumDescription = minimumDescription
 		self.maximumDescription = maximumDescription
 		self.gradientColors = gradientColors
-	}
-}
-
-extension CareKitEssentialSliderLogView: EventViewable {
-
-	public init?(
-		event: OCKAnyEvent,
-		store: any OCKAnyStoreProtocol
-	) {
-		self.init(
-			event: event
-		)
 	}
 }
 

--- a/Sources/CareKitEssentials/Cards/Shared/SliderLog/Slider.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/SliderLog/Slider.swift
@@ -16,6 +16,7 @@ struct Slider: View {
     @ObservedObject private var viewModel: SliderLogTaskViewModel
 
     private let range: (Double, Double)
+	private let sliderStyle: SliderStyle
     private let minimumImage: Image?
     private let maximumImage: Image?
     fileprivate let minimumDescription: String?
@@ -44,6 +45,7 @@ struct Slider: View {
         self.minimumDescription = minimumDescription
         self.maximumDescription = maximumDescription
         self.gradientColors = gradientColors
+		self.sliderStyle = style
         switch style {
         case .ticked:
             self.sliderHeight = 40
@@ -91,7 +93,7 @@ struct Slider: View {
                     .font(.system(size: valueFontSize))
                     .foregroundColor(.accentColor)
                     .fontWeight(.semibold)
-                    .padding(.bottom, 10)
+					.padding(.bottom)
                     .disabled(viewModel.isButtonDisabled)
 
                 HStack(spacing: 0) {
@@ -109,7 +111,6 @@ struct Slider: View {
                         .sliderImageModifier(width: imageWidth,
                                              height: usesSystemSlider ? imageWidth : sliderHeight!)
                 }
-                .padding(.bottom, 5)
 
                 HStack {
                     if containsImages {
@@ -119,11 +120,17 @@ struct Slider: View {
 
                     Text(minString)
                         .font(.system(size: boundsFontSize))
+						.if(sliderStyle == .system) { view in
+							view.padding(.top)
+						}
 
                     Spacer()
 
                     Text(maxString)
                         .font(.system(size: boundsFontSize))
+						.if(sliderStyle == .system) { view in
+							view.padding(.top)
+						}
 
                     if containsImages {
                         Spacer()
@@ -136,6 +143,7 @@ struct Slider: View {
 
     private func slider(frameWidth: CGFloat, imageWidth: CGFloat) -> some View {
         let sliderWidth = containsImages ? frameWidth - imageWidth * 2 - imageWidth / 2 : frameWidth
+		let sliderHeight = sliderHeight != nil ? sliderHeight! : 4
         let drag = DragGesture(minimumDistance: 0)
         return
             usesSystemSlider ?
@@ -146,10 +154,11 @@ struct Slider: View {
                             onDragChange(drag, sliderWidth: sliderWidth)
                         })
                     )
-                    .frame(width: sliderWidth, height: imageWidth)) :
+					.padding(.top)
+                    .frame(width: sliderWidth, height: sliderHeight/10)) :
             ViewBuilder.buildEither(
                 second: ZStack {
-                    fillerBarView(width: sliderWidth, height: sliderHeight!)
+                    fillerBarView(width: sliderWidth, height: sliderHeight)
                         .gesture(
                             drag.onChanged({ drag in
                                 onDragChange(drag, sliderWidth: sliderWidth)

--- a/Sources/CareKitEssentials/Cards/Shared/SliderLog/SliderLogTaskView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/SliderLog/SliderLogTaskView.swift
@@ -71,7 +71,7 @@ public struct SliderLogTaskView<Header: View, Slider: View>: View {
                     .if(isCardEnabled) { $0.padding([.horizontal]) }
 
                 VStack { slider }
-                    .if(isCardEnabled && isHeaderPadded) {
+                    .if(isCardEnabled && isSliderPadded) {
                         $0.padding([.horizontal, .bottom])
                     }
             }

--- a/Sources/CareKitEssentials/Cards/Shared/SliderLog/SliderLogTaskView.swift
+++ b/Sources/CareKitEssentials/Cards/Shared/SliderLog/SliderLogTaskView.swift
@@ -43,6 +43,8 @@ import SwiftUI
 ///     |                                                       |
 ///     +-------------------------------------------------------+
 /// ```
+/// - Note: You should use `SliderLogView` to take advantage of a working
+/// implementation of this view.
 public struct SliderLogTaskView<Header: View, Slider: View>: View {
 
     // MARK: - Properties

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownLogView.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownLogView.swift
@@ -16,7 +16,6 @@ import SwiftUI
 
 public typealias DigitalCrownLogView = CareKitEssentialDigitalCrownLogView
 
-
 /// A card that displays a header view, multi-line label, a digital crown modifier, and a
 /// completion button.
 ///

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownLogView.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownLogView.swift
@@ -1,5 +1,5 @@
 //
-//  CareKitEssentialDigitalCrownView.swift
+//  CareKitEssentialDigitalCrownLogView.swift
 //  CareKitEssentials
 //
 //  Created by Corey Baker on 5/4/25.
@@ -14,7 +14,7 @@ import CareKitUI
 import os.log
 import SwiftUI
 
-public typealias DigitalCrownLogView = CareKitEssentialDigitalCrownView
+public typealias DigitalCrownLogView = CareKitEssentialDigitalCrownLogView
 
 
 /// A card that displays a header view, multi-line label, a digital crown modifier, and a
@@ -47,17 +47,17 @@ public typealias DigitalCrownLogView = CareKitEssentialDigitalCrownView
 ///     |                                                       |
 ///     +-------------------------------------------------------+
 /// ```
-public struct CareKitEssentialDigitalCrownView: CareKitEssentialView {
+public struct CareKitEssentialDigitalCrownLogView: CareKitEssentialView {
 	@Environment(\.careStore) public var store
 
-	private(set) var event: OCKAnyEvent
-	@State public var kind: String?
-	@State public var initialValue: Double?
-	@State public var startValue: Double
-	@State public var endValue: Double?
-	@State public var step: Double
-	@State public var emojis: [String]
-	@State public var colorRatio: Double
+	var event: OCKAnyEvent
+	var kind: String?
+	var initialValue: Double?
+	var startValue: Double
+	var endValue: Double?
+	var step: Double
+	var emojis: [String]
+	var colorRatio: Double
 
 	public var body: some View {
 		DigitalCrownView(
@@ -130,7 +130,7 @@ struct CareKitEssentialDigitalCrownView_Previews: PreviewProvider {
 	static var previews: some View {
 		VStack {
 			if let event = try? Utility.createNauseaEvent() {
-				CareKitEssentialDigitalCrownView(
+				DigitalCrownLogView(
 					event: event,
 					emojis: emojis,
 					gradientColors: [.green, .yellow, .red]

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownView.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownView.swift
@@ -14,19 +14,52 @@ import CareKitUI
 import os.log
 import SwiftUI
 
-struct CareKitEssentialDigitalCrownView: CareKitEssentialView {
-	@Environment(\.careStore) var store
+public typealias DigitalCrownLogView = CareKitEssentialDigitalCrownView
 
-	let event: OCKAnyEvent
-	var kind: String?
-	var initialValue: Double?
-	var startValue: Double
-	var endValue: Double?
-	var step: Double
-	var emojis: [String]
-	var colorRatio: Double
 
-	var body: some View {
+/// A card that displays a header view, multi-line label, a digital crown modifier, and a
+/// completion button.
+///
+/// In CareKit, this view is intended to display a particular event for a task.
+/// The state of the button indicates the completion state of the event.
+///
+/// # Style
+/// The card supports styling using `careKitStyle(_:)`.
+///
+/// ```
+///     +-------------------------------------------------------+
+///     |                                                       |
+///     |  <Image> <Title>                       <Info Image>   |
+///     |  <Information>                                        |
+///     |                                                       |
+///     |  --------------------------------------------------   |
+///     |                                                       |
+///     |  <Instructions>                                       |
+///     |                                                       |
+///     |  <Min Image> –––––––––––––O–––––––––––– <Max Image>   |
+///     |             <Min Desc>        <Max Desc>              |
+///     |                                                       |
+///     |  +-------------------------------------------------+  |
+///     |  |                      <Log>                      |  |
+///     |  +-------------------------------------------------+  |
+///     |                                                       |
+///     |                   <Latest Value: >                    |
+///     |                                                       |
+///     +-------------------------------------------------------+
+/// ```
+public struct CareKitEssentialDigitalCrownView: CareKitEssentialView {
+	@Environment(\.careStore) public var store
+
+	private(set) var event: OCKAnyEvent
+	@State public var kind: String?
+	@State public var initialValue: Double?
+	@State public var startValue: Double
+	@State public var endValue: Double?
+	@State public var step: Double
+	@State public var emojis: [String]
+	@State public var colorRatio: Double
+
+	public var body: some View {
 		DigitalCrownView(
 			event: event,
 			kind: kind,
@@ -68,7 +101,7 @@ struct CareKitEssentialDigitalCrownView: CareKitEssentialView {
 	 - parameter emojis: An array of emoji's to show on the screen.
 	 - parameter colorRatio: The ratio effect on the color gradient.
 	 */
-	init(
+	public init(
 		event: OCKAnyEvent,
 		kind: String? = nil,
 		initialValue: Double? = nil,

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownView.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/CareKitEssentialDigitalCrownView.swift
@@ -1,0 +1,113 @@
+//
+//  CareKitEssentialDigitalCrownView.swift
+//  CareKitEssentials
+//
+//  Created by Corey Baker on 5/4/25.
+//  Copyright © 2025 Network Reconnaissance Lab. All rights reserved.
+//
+
+#if os(watchOS)
+
+import CareKit
+import CareKitStore
+import CareKitUI
+import os.log
+import SwiftUI
+
+struct CareKitEssentialDigitalCrownView: CareKitEssentialView {
+	@Environment(\.careStore) var store
+
+	let event: OCKAnyEvent
+	var kind: String?
+	var initialValue: Double?
+	var startValue: Double
+	var endValue: Double?
+	var step: Double
+	var emojis: [String]
+	var colorRatio: Double
+
+	var body: some View {
+		DigitalCrownView(
+			event: event,
+			kind: kind,
+			detailsTitle: event.title,
+			detailsInformation: event.detail,
+			initialValue: initialValue,
+			startValue: startValue,
+			endValue: endValue,
+			incrementValue: step,
+			emojis: emojis,
+			colorRatio: colorRatio,
+			action: { value -> OCKAnyOutcome in
+				guard let value else {
+					// Delete outcome values
+					let updatedOutcome = try await updateEvent(
+						event,
+						with: nil
+					)
+					return updatedOutcome
+				}
+
+				let updatedOutcome = try await updateEvent(
+					event,
+					with: [value]
+				)
+				return updatedOutcome
+			}
+		)
+	}
+
+	/**
+	 Create an instance with specified content for an event.
+	 - parameter event: A event to associate with the view model.
+	 - parameter kind: The kind of outcome value for the slider. Defaults to nil.
+	 - parameter initialValue: The initial value shown for the digital crown.
+	 - parameter startValue: The minimum possible value.
+	 - parameter endValue: The maximum possible value.
+	 - parameter step: Value to increment by when moving the digital crown. Default value is 1.
+	 - parameter emojis: An array of emoji's to show on the screen.
+	 - parameter colorRatio: The ratio effect on the color gradient.
+	 */
+	init(
+		event: OCKAnyEvent,
+		kind: String? = nil,
+		initialValue: Double? = nil,
+		startValue: Double = 0,
+		endValue: Double? = nil,
+		step: Double = 1,
+		emojis: [String] = [],
+		colorRatio: Double = 0.2,
+		gradientColors: [Color]? = nil
+	) {
+		self.event = event
+		self.kind = kind
+		self.initialValue = initialValue
+		self.startValue = startValue
+		self.endValue = endValue
+		self.step = step
+		self.emojis = emojis
+		self.colorRatio = colorRatio
+	}
+}
+
+struct CareKitEssentialDigitalCrownView_Previews: PreviewProvider {
+	static var store = Utility.createPreviewStore()
+	static let emojis = ["😄", "🙂", "😐", "😕", "😟", "☹️", "😞", "😓", "😥", "😰", "🤯"]
+
+	static var previews: some View {
+		VStack {
+			if let event = try? Utility.createNauseaEvent() {
+				CareKitEssentialDigitalCrownView(
+					event: event,
+					emojis: emojis,
+					gradientColors: [.green, .yellow, .red]
+				)
+			}
+		}
+		.environment(\.careStore, store)
+		.accentColor(.pink)
+		.padding()
+	}
+}
+
+#endif

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownView.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 NetReconLab. All rights reserved.
 //
 
+// swiftlint:disable vertical_parameter_alignment
 #if os(watchOS)
 
 import CareKit

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownView.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownView.swift
@@ -220,6 +220,7 @@ public extension DigitalCrownView where Header == DigitalCrownViewHeader, Footer
     ///   - action: The action to perform when the log button is tapped.
     init(
         event: OCKAnyEvent,
+		kind: String? = nil,
         detailsTitle: String? = nil,
         detailsInformation: String? = nil,
         initialValue: Double? = nil,
@@ -233,6 +234,7 @@ public extension DigitalCrownView where Header == DigitalCrownViewHeader, Footer
         let event = event
         let viewModel = DigitalCrownViewModel(
             event: event,
+			kind: kind,
             detailsTitle: detailsTitle,
             detailsInformation: detailsInformation,
             initialValue: initialValue,
@@ -270,14 +272,17 @@ struct DigitalCrownView_Previews: PreviewProvider {
     static let emojis = ["😄", "🙂", "😐", "😕", "😟", "☹️", "😞", "😓", "😥", "😰", "🤯"]
     static var previews: some View {
         if let event = try? Utility.createNauseaEvent() {
-            DigitalCrownView(
-                title: Text(event.task.title ?? ""),
-                detail: Text(event.task.instructions ?? ""),
-                viewModel: .init(
-                    event: event,
-                    emojis: emojis
-                )
-            )
+			VStack {
+				DigitalCrownView(
+					title: Text(event.task.title ?? ""),
+					detail: Text(event.task.instructions ?? ""),
+					viewModel: .init(
+						event: event,
+						emojis: emojis
+					)
+				)
+				.padding()
+			}
             .environment(\.careStore, Utility.createPreviewStore())
             .careKitStyle(OCKStyle())
         }

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownView.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownView.swift
@@ -15,6 +15,38 @@ import CareKitUI
 import Foundation
 import SwiftUI
 
+/// A card that displays a header view, multi-line label, a digital crown modifier, and a
+/// completion button.
+///
+/// In CareKit, this view is intended to display a particular event for a task.
+/// The state of the button indicates the completion state of the event.
+///
+/// # Style
+/// The card supports styling using `careKitStyle(_:)`.
+///
+/// ```
+///     +-------------------------------------------------------+
+///     |                                                       |
+///     |  <Image> <Title>                       <Info Image>   |
+///     |  <Information>                                        |
+///     |                                                       |
+///     |  --------------------------------------------------   |
+///     |                                                       |
+///     |  <Instructions>                                       |
+///     |                                                       |
+///     |  <Min Image> –––––––––––––O–––––––––––– <Max Image>   |
+///     |             <Min Desc>        <Max Desc>              |
+///     |                                                       |
+///     |  +-------------------------------------------------+  |
+///     |  |                      <Log>                      |  |
+///     |  +-------------------------------------------------+  |
+///     |                                                       |
+///     |                   <Latest Value: >                    |
+///     |                                                       |
+///     +-------------------------------------------------------+
+/// ```
+/// - Note: You should use `DigitalCrownLogView` to take advantage of a working
+/// implementation of this view.
 public struct DigitalCrownView<Header: View, Footer: View>: View {
 
     // MARK: - Properties

--- a/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownViewFooter.swift
+++ b/Sources/CareKitEssentials/Cards/watchOS/DigitalCrown/DigitalCrownViewFooter.swift
@@ -19,11 +19,11 @@ public struct DigitalCrownViewFooter: CareKitEssentialView {
     @StateObject var viewModel: DigitalCrownViewModel
 
     @OSValue<Font>(
-        values: [.watchOS: .system(size: 15)],
+        values: [.watchOS: .system(size: 14)],
         defaultValue: .title
     ) private var font
 
-    private var content: some View {
+    private var buttonContent: some View {
         Group {
             if viewModel.isButtonDisabled {
                 HStack {
@@ -64,7 +64,7 @@ public struct DigitalCrownViewFooter: CareKitEssentialView {
                 RectangularCompletionView(isComplete: viewModel.isButtonDisabled) {
                     HStack {
                         Spacer()
-                        content
+						buttonContent
 							.font(font)
                         Spacer()
                     }

--- a/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy.swift
+++ b/Sources/CareKitEssentials/Extensions/CareTaskProgressStrategy.swift
@@ -13,7 +13,7 @@ public extension CareTaskProgressStrategy {
 	/// A strategy that computes progress for a task by checking for the existence of an outcome.
 	///
 	/// - Parameters:
-	/// - kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
+	/// 	- kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
 	/// when computing the progress for the event. Defaults to ``nil``.
 	///
 	/// The task is considered completed if an ``OCKAnyEvent/outcome`` exists that contains an
@@ -30,7 +30,7 @@ public extension CareTaskProgressStrategy {
 	/// the two results. The task is considered completed if the summed value reaches the summed target.
 	///
 	/// - Parameters:
-	/// - kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
+	/// 	- kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
 	/// when computing the progress for the event. Defaults to ``nil``.
 	///
 	/// - Note:
@@ -49,7 +49,7 @@ public extension CareTaskProgressStrategy {
 	/// the two results. The task is considered completed if the max value reaches the max target.
 	///
 	/// - Parameters:
-	/// - kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
+	/// 	- kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
 	/// when computing the progress for the event. Defaults to ``nil``.
 	///
 	/// - Note:
@@ -68,7 +68,7 @@ public extension CareTaskProgressStrategy {
 	/// the two results. The task is considered completed if the min value reaches the min target.
 	///
 	/// - Parameters:
-	/// - kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
+	/// 	- kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
 	/// when computing the progress for the event. Defaults to ``nil``.
 	///
 	/// - Note:
@@ -89,7 +89,7 @@ public extension CareTaskProgressStrategy {
     ///
     ///
 	/// - Parameters:
-	/// - kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
+	/// 	- kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
 	/// when computing the progress for the event. Defaults to ``nil``.
     ///
     /// - Returns: A ``CareTaskProgressStrategy<LinearCareTaskProgress>`` 
@@ -109,7 +109,7 @@ public extension CareTaskProgressStrategy {
     /// Event is pased to the ``computeProgressByMedianOutcomeValues`` method as an argument
     ///
 	/// - Parameters:
-	/// - kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
+	/// 	- kind: An optional ``String`` that specifies the kind of the `OCKOutcomeValue` to use
 	/// when computing the progress for the event. Defaults to ``nil``.
     ///
     /// - Returns: A ``CareTaskProgressStrategy<LinearCareTaskProgress>``


### PR DESCRIPTION
- [x] Add `SliderLogView`, which is an OOTB implementation of `SliderLogTaskView` by conforming to `CareKitEssentialView`. This allows developers not to have to implement a ViewModel and handles the logic for them
- [x] Add `DigitalCrownLogView`, which is an OOTB implementation of `DigitalCrownView` by conforming to `CareKitEssentialView`. This allows developers not to have to implement a ViewModel and handles the logic for them 
- [x] Expose `CartView`, which is a `typealias` for `CareKitEssentialChartView`
- [x] Add `max` and `min` `CKEDataSeriesConfiguration.DataStrategy`'s. This is useful when trying to graph `OCKHealthKitOutcome`'s
- [x] Fix `InformatinHeaderView` on visionOS
- [x] Remove some hardcoded padding in various cards to show better on more OS's  
- [x] Documentation improvements  