### PR TITLE
fix: Use Event comparable from CareKit

### DIFF
--- a/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Comparable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Comparable.swift
@@ -8,12 +8,6 @@
 
 import CareKitStore
 
-extension OCKEvent: Comparable where Task: CareKitEssentialVersionable, Outcome: CareKitEssentialVersionable {
-	public static func < (lhs: OCKEvent, rhs: OCKEvent) -> Bool {
-		lhs.scheduleEvent < rhs.scheduleEvent
-	}
-}
-
 extension OCKAnyEvent: Comparable {
     public static func < (lhs: OCKAnyEvent, rhs: OCKAnyEvent) -> Bool {
 		lhs.scheduleEvent < rhs.scheduleEvent

--- a/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Comparable.swift
+++ b/Sources/CareKitEssentials/Extensions/OCKAnyEvent+Comparable.swift
@@ -9,7 +9,28 @@
 import CareKitStore
 
 extension OCKAnyEvent: Comparable {
-    public static func < (lhs: OCKAnyEvent, rhs: OCKAnyEvent) -> Bool {
-		lhs.scheduleEvent < rhs.scheduleEvent
-    }
+
+	func isOrderedBefore(other: OCKAnyEvent) -> Bool {
+
+		if scheduleEvent.start != other.scheduleEvent.start {
+			return scheduleEvent.start < other.scheduleEvent.start
+		}
+
+		if task.uuid != other.task.uuid {
+			return task.uuid.uuidString < other.task.uuid.uuidString
+		}
+
+		// At this point, the two events belong to the same task version and occur at the same time. Sort by occurrence
+		// which should be guaranteed to be increasing between two events for the same task version.
+
+		if scheduleEvent.occurrence == other.scheduleEvent.occurrence {
+			assertionFailure("Unexpectedly found two events for the same task version with equal occurrences")
+		}
+
+		return scheduleEvent.occurrence < other.scheduleEvent.occurrence
+	}
+
+	public static func < (lhs: Self, rhs: Self) -> Bool {
+		lhs.isOrderedBefore(other: rhs)
+	}
 }


### PR DESCRIPTION
Comparable was added in https://github.com/carekit-apple/CareKit/pull/727